### PR TITLE
Initial tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: ["push", "pull_request"]
+
+jobs:
+
+  tests:
+
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9"]
+
+    steps:
+
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - name: Install package and run unit tests
+        run: |
+          pip install .
+          python setup.py test
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.pyc
 *~
 *.egg-info/
+build/
+dist/
+
+*.vcf
+*.vcf.gz
+*.db

--- a/tests/test_readvcf.py
+++ b/tests/test_readvcf.py
@@ -1,0 +1,10 @@
+import unittest
+
+from svdb.readVCF import readVCFLine
+
+
+class TestReadVCFLine(unittest.TestCase):
+
+    def test_comment(self):
+        line = '# This is a comment'
+        self.assertIsNone(readVCFLine(line))


### PR DESCRIPTION
This adds a single test as a starting point to more testing of codebase.
Additionally I've added CI for python 2.7, 3.6-3.9.

There is still a long way to go in order to test everything, but it will come with refactoring into smaller pieces of functions.

The test is run by:
`$ python setup.py test`