### PR TITLE
Add missing header infomation in svdb query output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
     ext_modules = []
 
 setup(name='svdb',
-      version='2.5.2',
+      version='2.5.3',
       url="https://github.com/J35P312/SVDB",
       author="Jesper Eisfeldt",
       author_email="jesper.eisfeldt@scilifelab.se",

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -36,7 +36,7 @@ def make_query_calls (args, queries, keyword):
         query_module.main(args)
 
 def main():
-    version = "2.5.2"
+    version = "2.5.3"
     parser = argparse.ArgumentParser(
         """SVDB-{}, use the build module to construct databases, use the query module to query the database usign vcf files, or use the hist module to generate histograms""".format(version), add_help=False)
     parser.add_argument('--build', help="create a db",

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -40,7 +40,9 @@ def main(args):
                         noOCCTag = 0
                 else:
                     if line[1] != "#":
-                        writer("##SVDB_version={} cmd=\"{}\"".format(args.version, " ".join(sys.argv)))
+                        writer("##SVDB_version={} cmd=\"{}\"\n".format(args.version, " ".join(sys.argv)))
+                        writer(line)
+                    else:
                         writer(line)
                 continue
 


### PR DESCRIPTION
The output from svdb query module only contained INFO headers and nothing else. This PR fixes that.  