### PR TITLE
Feat/fix picarderror

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
     ext_modules = []
 
 setup(name='svdb',
-      version='2.6.0',
+      version='2.6.1',
       url="https://github.com/J35P312/SVDB",
       author="Jesper Eisfeldt",
       author_email="jesper.eisfeldt@scilifelab.se",

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -36,7 +36,7 @@ def make_query_calls (args, queries, keyword):
         query_module.main(args)
 
 def main():
-    version = "2.6.0"
+    version = "2.6.1"
     parser = argparse.ArgumentParser(
         """SVDB-{}, use the build module to construct databases, use the query module to query the database usign vcf files, or use the hist module to generate histograms""".format(version), add_help=False)
     parser.add_argument('--build', help="create a db",

--- a/svdb/merge_vcf_module_cython.py
+++ b/svdb/merge_vcf_module_cython.py
@@ -348,7 +348,7 @@ def merge(variants, samples, sample_order, sample_print_order, priority_order, a
                 line[7]+=";{}_FILTERS={}".format(tag,",".join(filters_tag[tag]))
             #add samples information for all merged variants
             for tag in samples_tag:
-                line[7]+=";{}_SAMPLES={}".format(tag,",".join(samples_tag[tag]))
+                line[7]+=";{}_SAMPLE={}".format(tag,",".join(samples_tag[tag]))
             #add info column for all merged variants
             for tag in samples_tag:
                 line[7]+=";{}_INFO={}".format(tag,",".join(info_tag[tag]))


### PR DESCRIPTION
Picard's Validation fails because the key <caller>_SAMPLES found in Vcf body isn't defined in the VCFHeader. This PR fixes that.