### PR TITLE
update tmp file names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
     ext_modules = []
 
 setup(name='svdb',
-      version='2.7.0',
+      version='2.7.1',
       url="https://github.com/J35P312/SVDB",
       author="Jesper Eisfeldt",
       author_email="jesper.eisfeldt@scilifelab.se",

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -40,7 +40,7 @@ def make_query_calls (args, queries, keyword):
         query_module.main(args)
 
 def main():
-    version = "2.7.0"
+    version = "2.7.1"
     parser = argparse.ArgumentParser(
         """SVDB-{}, use the build module to construct databases, use the query module to query the database usign vcf files, or use the hist module to generate histograms""".format(version), add_help=False)
     parser.add_argument('--build', help="create a db",

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -26,12 +26,14 @@ def make_query_calls (args, queries, keyword):
                     args.out_frq     = out_frqs[ind]
                     if ind < len(queries)-1:
                         args.prefix  = orig_prefix + "_" + str(ind)
+                        output_file  = args.prefix + "_query.vcf_tmp"    
                     else:
                         args.prefix = orig_prefix
-                    query_module.main(args)
+                        output_file  = args.prefix + "_query.vcf"    
+                    query_module.main(args, output_file)
                     if ind > 0:
                         os.remove(args.query_vcf)
-                    args.query_vcf = args.prefix + "_query.vcf"
+                    args.query_vcf = output_file
         else:
             print("please ensure that both count and frequency tags are specified for all samples")
     else:

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -8,11 +8,11 @@ import numpy as np
 from . import database, overlap_module, readVCF
 
 
-def main(args):
+def main(args, output_file):
     # start by loading the variations
     queries = []
     if args.prefix:
-        f = open(args.prefix + "_query.vcf", "w")
+        f = open(output_file, "w")
     noOCCTag = 1
     infoFound = 0
 


### PR DESCRIPTION
This PR modifies the output file names for the intermediary files when the user provides a list of databases as an input. 

Rationale: 

When there is an issue with one of the databases in the list of dbs provided by the user, svdb throws an error. However, this doesn't work well when svdb is run as a process in nextflow, where the process is expecting a ".vcf" output to determine successful completion. In such cases it simply picks up one of the intermediary files with a ".vcf" extension and proceeds as if there were no errors.
