### PR TITLE
Fix argument mismatch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
     ext_modules = []
 
 setup(name='svdb',
-      version='2.7.1',
+      version='2.7.2',
       url="https://github.com/J35P312/SVDB",
       author="Jesper Eisfeldt",
       author_email="jesper.eisfeldt@scilifelab.se",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
     ext_modules = []
 
 setup(name='svdb',
-      version='2.7.0',
+      version='2.7.1',
       url="https://github.com/J35P312/SVDB",
       author="Jesper Eisfeldt",
       author_email="jesper.eisfeldt@scilifelab.se",

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -36,19 +36,17 @@ def make_query_calls (args, queries, keyword):
                     args.query_vcf = output_file
         else:
             print("please ensure that both count and frequency tags are specified for all samples")
+    elif len(queries) > 1 and not args.prefix:
+        print("ERROR: Please provide a prefix")
+        quit()
     elif len(queries) == 1 and args.prefix:
         output_file  = args.prefix + "_query.vcf"    
         query_module.main(args, output_file)
     else:
-        if args.prefix:
-            output_file  = args.prefix + "_query.vcf"    
-        else:
-            output_file=None
-
-        query_module.main(args,output_file)
+        query_module.main(args)
 
 def main():
-    version = "2.8.0"
+    version = "2.8.1"
     parser = argparse.ArgumentParser(
         """SVDB-{}, use the build module to construct databases, use the query module to query the database usign vcf files, or use the hist module to generate histograms""".format(version), add_help=False)
     parser.add_argument('--build', help="create a db",

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -36,6 +36,9 @@ def make_query_calls (args, queries, keyword):
                     args.query_vcf = output_file
         else:
             print("please ensure that both count and frequency tags are specified for all samples")
+    elif len(queries) == 1 and args.prefix:
+        output_file  = args.prefix + "_query.vcf"    
+        query_module.main(args, output_file)
     else:
         query_module.main(args)
 

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -40,7 +40,7 @@ def make_query_calls (args, queries, keyword):
         query_module.main(args)
 
 def main():
-    version = "2.7.0"
+    version = "2.7.1"
     parser = argparse.ArgumentParser(
         """SVDB-{}, use the build module to construct databases, use the query module to query the database usign vcf files, or use the hist module to generate histograms""".format(version), add_help=False)
     parser.add_argument('--build', help="create a db",

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -8,10 +8,11 @@ import numpy as np
 from . import database, overlap_module, readVCF
 
 
-def main(args, output_file):
+def main(args, output_file=None):
     # start by loading the variations
     queries = []
     if args.prefix:
+        output_file  = args.prefix + "_query.vcf"    
         f = open(output_file, "w")
     noOCCTag = 1
     infoFound = 0

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -12,7 +12,6 @@ def main(args, output_file=None):
     # start by loading the variations
     queries = []
     if args.prefix:
-        output_file  = args.prefix + "_query.vcf"    
         f = open(output_file, "w")
     noOCCTag = 1
     infoFound = 0


### PR DESCRIPTION
When the query module was called with one db, it led to an error because there was a mismatch in the number of arguments in the function call vs. what the function took. In this PR, I have changed the function call so that the second argument is now an optional argument.