### PR TITLE
Pick the closest insertion among several insertion matches when --ins_distance > 0

### DIFF
--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -253,6 +253,8 @@ def queryVCFDB(DBvariants, query_variant, args, use_OCC_tag):
         if occ:
             if not (chrA == chrB):
                 idx = similarity.index(min(similarity))
+            elif "INS" in variation_type:
+                idx = similarity.index(min(similarity))
             else:
                 idx = similarity.index(max(similarity))
             hits = [occ[idx], frequency[idx]]


### PR DESCRIPTION
fixes #77 

In short, this PR fixes the behavior where when `--ins_distance` > 0 and when there are several insertions matching the query INS, then SVDB would pick the insertion with the greatest distance from the queried insertion.