### PR TITLE
Feature/sqlite ins seq

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ This module is used to construct structural variant databases from vcf files. Th
         svdb --build --folder SV_analysis_folder/
     Upgrade an existing database schema to the current SVDB version:
         svdb --build --upgrade --prefix existing_db
-    Upgrade schema and add new samples in one step:
-        svdb --build --upgrade --files new_sample.vcf --prefix existing_db
+    Upgrade schema and backfill insertion data from the original VCFs:
+        svdb --build --upgrade --files sample1.vcf sample2.vcf --prefix existing_db
 
     optional arguments:
         -h, --help                      show this help message and exit
@@ -164,23 +164,23 @@ The query module is used to query one or more structural variant databases. Typi
         --ins_svlen_ratio INS_SVLEN_RATIO
                                 minimum SVLEN ratio (min/max) required to match two insertions
                                 with known length (default = 0.90)
-                                Note: only applied when using --db; has no effect with --sqdb
-                                or --bedpedb
+                                Applied with --db; also applied with --sqdb when the database
+                                contains the INS table; no effect with --bedpedb
         --ins_seq_similarity THRESHOLD
                                 minimum Levenshtein sequence similarity (0–1) required to match
                                 two insertions with known sequence (default = 0.75); overridden
                                 by --data_profile
-                                Note: only applied when using --db; has no effect with --sqdb
-                                or --bedpedb
+                                Applied with --db; also applied with --sqdb when the database
+                                contains the INS table; no effect with --bedpedb
         --data_profile {sample,cohort}
                                 set a sequence similarity preset: sample=0.85, cohort=0.75;
                                 overrides --ins_seq_similarity
-                                Note: only applied when using --db; has no effect with --sqdb
-                                or --bedpedb
+                                Applied with --db; also applied with --sqdb when the database
+                                contains the INS table; no effect with --bedpedb
         --no_ins_seq            disable insertion sequence similarity check; match insertions on
                                 position and SVLEN only
-                                Note: only applied when using --db; has no effect with --sqdb
-                                or --bedpedb
+                                Applied with --db; also applied with --sqdb when the database
+                                contains the INS table; no effect with --bedpedb
         --memory                load the database into memory: increases the memory requirements,
                                 but lowers the time consumption (may only be used with sqdb)
         --no_var                count overlapping variants of different type as hits in the db

--- a/README.md
+++ b/README.md
@@ -93,23 +93,43 @@ When the database was built with insertion sequence data (i.e. the INS table is 
         svdb --export --db database.db
 
     optional arguments:
-        --no_merge            skip the merging of variants, print all variants in the db to a vcf file
+        --no_merge                  skip the merging of variants, print all variants in the db to a vcf file
 
-         --bnd_distance BND_DISTANCE  the maximum distance between two similar precise breakpoints(default = 2500)
- 
-         --overlap OVERLAP     the overlap required to merge two events(0 means anything that touches will be merged, 1 means that two events must be identical to be merged), default = 0.8
+        --bnd_distance BND_DISTANCE the maximum distance between two similar precise breakpoints (default = 2500)
 
-         --DBSCAN              use dbscan to cluster the variants, overides the overlap based clustering algorithm
+        --ins_distance INS_DISTANCE the maximum distance to cluster two insertions (default = 25)
 
-         --epsilon EPSILON     used together with --DBSCAN; sets the epsilon parameter(default = 500bp)
+        --ins_svlen_ratio RATIO      minimum SVLEN ratio (min/max) for insertion clustering (default = 0.90);
+                                    requires INS table
 
-         --min_pts MIN_PTS     the min_pts parameter(default = 2
+        --ins_seq_similarity THRESHOLD
+                                    minimum Levenshtein sequence similarity (0–1) for insertion clustering
+                                    (default = 0.75); overridden by --data_profile; requires INS table
 
-         --prefix PREFIX       the prefix of the output file, default = same as input
+        --data_profile {sample,cohort}
+                                    set a sequence similarity preset: sample=0.85, cohort=0.75;
+                                    overrides --ins_seq_similarity; requires INS table
 
-          --memory              load the database into memory: increases the memory requirements, but lowers the time consumption
+        --no_ins_seq                disable insertion sequence similarity check for clustering;
+                                    cluster on position and SVLEN only; requires INS table
 
-          --debug               enable debug logging to stderr
+        --overlap OVERLAP           the overlap required to merge two events (0 means anything that
+                                    touches will be merged, 1 means that two events must be identical
+                                    to be merged), default = 0.8
+
+        --DBSCAN                    use dbscan to cluster the variants, overrides the overlap based
+                                    clustering algorithm
+
+        --epsilon EPSILON           used together with --DBSCAN; sets the epsilon parameter (default = 500bp)
+
+        --min_pts MIN_PTS           the min_pts parameter (default = 2)
+
+        --prefix PREFIX             the prefix of the output file, default = same as input
+
+        --memory                    load the database into memory: increases the memory requirements,
+                                    but lowers the time consumption
+
+        --debug                     enable debug logging to stderr
 
 ## Query
 The query module is used to query one or more structural variant databases. Typically a database is constructed using the build module. However, since this module utilize the genotype field of the structural variant database vcf to compute the frequency of structural variants, a wide range of files could be used as database. The query module requires a query vcf, as well as a database file(either multisample vcf or SVDB sqlite database):

--- a/README.md
+++ b/README.md
@@ -121,9 +121,26 @@ The query module is used to query one or more structural variant databases. Typi
         --out_occ OUT_OCC       the allele count tag, as annotated by SVDB variant(default=OCC). This parameter is required if multiple databases are queried.
         --out_frq OUT_FRQ       the tag used to describe the frequency of the variant(default=FRQ). This parameter is required if multiple databases are queried.
         --prefix PREFIX         the prefix of the output file, default = print to stdout. Required if multiple databases are queried.
-        --bnd_distance BND_DISTANCE  the maximum distance between two similar breakpoints(default = 10000)
-        --overlap OVERLAP       the overlap required to merge two events(0 means anything that touches will be merged, 1 means that two events must be identical to be merged), default = 0.6
-        --memory                load the database into memory: increases the memory requirements, but lowers the time consumption(may only be used with sqdb)
+        --bnd_distance BND_DISTANCE  the maximum distance between two similar breakpoints (default = 10000)
+        --overlap OVERLAP       the overlap required to merge two events (0 means anything that
+                                touches will be merged, 1 means that two events must be identical
+                                to be merged), default = 0.6
+        --ins_distance INS_DISTANCE
+                                the maximum distance to match two insertions (default = 50)
+        --ins_svlen_ratio INS_SVLEN_RATIO
+                                minimum SVLEN ratio (min/max) required to match two insertions
+                                with known length (default = 0.90; VCF db only)
+        --ins_seq_similarity THRESHOLD
+                                minimum Levenshtein sequence similarity (0–1) required to match
+                                two insertions with known sequence (default = 0.75); overridden
+                                by --data_profile; VCF db only
+        --data_profile {sample,cohort}
+                                set a sequence similarity preset: sample=0.85, cohort=0.75;
+                                overrides --ins_seq_similarity; VCF db only
+        --no_ins_seq            disable insertion sequence similarity check; match insertions on
+                                position and SVLEN only; VCF db only
+        --memory                load the database into memory: increases the memory requirements,
+                                but lowers the time consumption (may only be used with sqdb)
         --no_var                count overlapping variants of different type as hits in the db
         --debug                 enable debug logging to stderr
 
@@ -146,23 +163,42 @@ The merge module merges variants within one or more vcf files. This could be use
 
     optional arguments:
         -h, --help                      show this help message and exit
-        
+
         --bnd_distance BND_DISTANCE     the maximum distance between two similar precise breakpoints
-                                        (default = 10000)
-                        
-        --overlap OVERLAP               the overlap required to merge two events(0 means
+                                        (default = 2000)
+
+        --overlap OVERLAP               the overlap required to merge two events (0 means
                                         anything that touches will be merged, 1 means that two
-                                        events must be identical to be merged), default = 0.6
+                                        events must be identical to be merged), default = 0.95
+
+        --ins_distance INS_DISTANCE     the maximum distance to merge two insertions (default = 25)
+
+        --ins_svlen_ratio INS_SVLEN_RATIO
+                                        minimum SVLEN ratio (min/max) required to merge two
+                                        insertions with known length (default = 0.90)
+
+        --ins_seq_similarity THRESHOLD  minimum Levenshtein sequence similarity (0–1) required to
+                                        merge two insertions with known sequence (default = 0.75);
+                                        overridden by --data_profile
+
+        --data_profile {sample,cohort}  set a sequence similarity preset: sample=0.85 (same
+                                        individual / same technology), cohort=0.75 (cross-
+                                        individual or cross-technology); overrides
+                                        --ins_seq_similarity
+
+        --no_ins_seq                    disable insertion sequence similarity check; merge
+                                        insertions on position and SVLEN only
 
         --priority                      prioritise the input vcf files
-                                                                      
+
         --no_intra                      no merging of variants within the same vcf
-        
+
         --no_var                        variants of different type will be merged
-        
+
         --pass_only                     merge only variants labeled PASS
 
-        --same_order                    assume that the samples are ordered the same way (skip reordering and merging of the sample columns).
+        --same_order                    assume that the samples are ordered the same way (skip
+                                        reordering and merging of the sample columns)
 
         --debug                         enable debug logging to stderr
 

--- a/README.md
+++ b/README.md
@@ -49,25 +49,37 @@ SVDB consists of modules that are used to build, query, export, and analyse stru
 
 ## Build
 This module is used to construct structural variant databases from vcf files. The database may then be queried to compute the frequency of structural variants, or exported into a vcf file. These are the commands used to construct a structural variation database:
-    
+
     print a help message
-        svdb  --build --help  
-    Construct a database, from a set of vcf files:
+        svdb  --build --help
+    Construct a database from a set of vcf files:
         svdb --build --files sample1.vcf sample2.vcf sample3.vcf
-    construct a database from vcf files stored in a folder
+    Construct a database from vcf files stored in a folder:
         svdb --build --folder SV_analysis_folder/
-        
+    Upgrade an existing database schema to the current SVDB version:
+        svdb --build --upgrade --prefix existing_db
+    Upgrade schema and add new samples in one step:
+        svdb --build --upgrade --files new_sample.vcf --prefix existing_db
+
     optional arguments:
         -h, --help                      show this help message and exit
 
-        --files [FILES [FILES ...]]      create a db using the specified vcf files(cannot be
-                                         used with --folder)
-                        
-        --folder FOLDER                  create a db using all the vcf files in the folders
-        
-        --prefix PREFIX                  the prefix of the output file, default = SVDB
+        --files [FILES [FILES ...]]      create a db using the specified vcf files (cannot be
+                                        used with --folder)
 
-        --debug                          enable debug logging to stderr
+        --folder FOLDER                 create a db using all the vcf files in the folders
+
+        --prefix PREFIX                 the prefix of the output file, default = SVDB
+
+        --upgrade                       create the INS sequence/length table in an existing
+                                        database (safe to run on any database; exits with INFO
+                                        if already up to date). Optionally combine with --files
+                                        or --folder to backfill insertion data from the original
+                                        VCFs without rebuilding the full database.
+
+        --passonly                      only include variants with PASS or . in the FILTER field
+
+        --debug                         enable debug logging to stderr
 
 
 ## Export

--- a/README.md
+++ b/README.md
@@ -126,19 +126,27 @@ The query module is used to query one or more structural variant databases. Typi
                                 touches will be merged, 1 means that two events must be identical
                                 to be merged), default = 0.6
         --ins_distance INS_DISTANCE
-                                the maximum distance to match two insertions (default = 50)
+                                the maximum distance to match two insertions (default = 25)
         --ins_svlen_ratio INS_SVLEN_RATIO
                                 minimum SVLEN ratio (min/max) required to match two insertions
-                                with known length (default = 0.90; VCF db only)
+                                with known length (default = 0.90)
+                                Note: only applied when using --db; has no effect with --sqdb
+                                or --bedpedb
         --ins_seq_similarity THRESHOLD
                                 minimum Levenshtein sequence similarity (0–1) required to match
                                 two insertions with known sequence (default = 0.75); overridden
-                                by --data_profile; VCF db only
+                                by --data_profile
+                                Note: only applied when using --db; has no effect with --sqdb
+                                or --bedpedb
         --data_profile {sample,cohort}
                                 set a sequence similarity preset: sample=0.85, cohort=0.75;
-                                overrides --ins_seq_similarity; VCF db only
+                                overrides --ins_seq_similarity
+                                Note: only applied when using --db; has no effect with --sqdb
+                                or --bedpedb
         --no_ins_seq            disable insertion sequence similarity check; match insertions on
-                                position and SVLEN only; VCF db only
+                                position and SVLEN only
+                                Note: only applied when using --db; has no effect with --sqdb
+                                or --bedpedb
         --memory                load the database into memory: increases the memory requirements,
                                 but lowers the time consumption (may only be used with sqdb)
         --no_var                count overlapping variants of different type as hits in the db

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ When the database was built with insertion sequence data (i.e. the INS table is 
         --memory                    load the database into memory: increases the memory requirements,
                                     but lowers the time consumption
 
+        --strip_chr                 strip the 'chr' prefix from chromosome names in the output VCF
+                                    (e.g. 'chr1' → '1')
+
         --debug                     enable debug logging to stderr
 
 ## Query

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This module is used to construct structural variant databases from vcf files. Th
 
 ## Export
 This module is used to export the variants of the SVDB sqlite database. The variants of the sqlite svdb database is clustered using one out of three algorithms, overlap or DBSCAN.
+
+When the database was built with insertion sequence data (i.e. the INS table is present), insertions are exported with the actual insertion sequence in the ALT column instead of the symbolic `<INS>` allele. For clusters containing multiple samples, the most common sequence across the cluster is used as the representative ALT allele. If the INS table is absent (older database), a warning is emitted and insertions are exported as `<INS>`; run `svdb --build --upgrade --files <original_vcfs> --prefix <existing_db>` to create the INS table and backfill insertion data from the original VCFs.
  
     print a help message
         svdb  --export --help  

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,16 +5,17 @@
 | Module | Role |
 |---|---|
 | `__main__` | CLI entry point; argument parsing, logging setup, command dispatch |
-| `build_module` | Populates a SQLite database from VCF/gzip-VCF files |
-| `query_module` | Annotates a query VCF with OCC/FRQ from a VCF or SQLite database |
+| `build_module` | Populates a SQLite database (SVDB + INS tables) from VCF files; `--upgrade` for schema migration |
+| `query_module` | Annotates a query VCF with OCC/FRQ; supports SVLEN + sequence gates for insertions |
 | `merge_vcf_module` | Merges SV calls from multiple callers/samples into one VCF |
 | `merge_vcf_module_cython` | Pure-Python merge logic (optionally Cython-compiled) |
-| `export_module` | Exports a SQLite database to VCF with overlap-based clustering |
+| `export_module` | Exports a SQLite database to VCF; uses INS table for sequence-aware ALT column and clustering |
+| `ins_similarity` | Insertion sequence gate: Levenshtein similarity, threshold resolution (`--data_profile` / `--ins_seq_similarity`) |
 | `read_vcf` | Parses a single VCF data line into a `VCFVariant` |
 | `vcf_utils` | Shared I/O helpers: `open_vcf`, `normalize_chrom`, `parse_info_field`, `parse_ci` |
 | `overlap_module` | Geometric overlap tests between two SV coordinates |
 | `dbscan` | DBSCAN clustering used by the export module |
-| `database` | Thin SQLite wrapper (`DB` class) |
+| `database` | SQLite wrapper (`DB` class): SVDB + INS tables, context manager |
 | `models` | Shared data classes: `VCFVariant`, `MergeVariant` |
 
 ## Module dependencies
@@ -34,15 +35,19 @@ graph TD
     query_module --> read_vcf
     query_module --> vcf_utils
     query_module --> overlap_module
+    query_module --> ins_similarity
 
     merge_vcf_module --> read_vcf
     merge_vcf_module --> vcf_utils
     merge_vcf_module --> merge_vcf_module_cython
+    merge_vcf_module --> ins_similarity
     merge_vcf_module_cython --> overlap_module
+    merge_vcf_module_cython --> ins_similarity
 
     export_module --> database
     export_module --> overlap_module
     export_module --> dbscan
+    export_module --> ins_similarity
 
     read_vcf --> vcf_utils
     read_vcf --> models
@@ -62,6 +67,9 @@ classDiagram
         +str event_type
         +dict info
         +dict fmt
+        +str ins_seq
+        +int svlen
+        +str vcf_filter
         +is_interchromosomal() bool
         +is_insertion() bool
         +is_precise() bool
@@ -76,6 +84,9 @@ classDiagram
         +str source
         +int sort_index
         +str raw_line
+        +str ins_seq
+        +int svlen
+        +str vcf_filter
         +is_insertion() bool
     }
 
@@ -85,7 +96,11 @@ classDiagram
         +drop(sql)
         +create(sql)
         +insert_many(data)
+        +insert_ins_many(data)
         +create_index(name, columns)
+        +create_ins_table()
+        +has_ins_table() bool
+        +close()
         +tables list
         +sample_ids list
     }
@@ -95,28 +110,47 @@ classDiagram
 
 **`svdb --build`**
 ```
-VCF files → read_vcf.readVCFLine → VCFVariant → build_module.populate_db → SQLite (.db)
+VCF files → read_vcf.readVCFLine → VCFVariant
+  → populate_db → SVDB table (coordinates, samples)
+                → INS table   (ins_seq, ins_len per insertion idx)
+  → SQLite (.db)
+```
+
+**`svdb --build --upgrade`**
+```
+Existing SQLite (.db) → upgrade_db
+  → CREATE INS table (if absent)
+  → optional: VCF files → backfill INS rows matched by SVDB idx
 ```
 
 **`svdb --query`**
 ```
 query VCF → _read_query_vcf → variant list
-DB (VCF/BEDPE/SQLite) → _load_vcf_db / SQDB
-overlap_module.{precise_overlap, isSameVariation} → OCC/FRQ → annotated VCF (stdout or file)
+DB (VCF/BEDPE)  → _load_vcf_db → queryVCFDB
+                   ins_similarity.sequence_gate + insertion_svlen_match → OCC/FRQ
+DB (SQLite)     → SQDB
+                   LEFT JOIN INS (when INS table present)
+                   ins_similarity.sequence_gate + insertion_svlen_match → OCC/FRQ
+→ annotated VCF (stdout or file)
 ```
 
 **`svdb --merge`**
 ```
 VCF files → MergeVariant list (per chrA)
-merge_vcf_module_cython.merge → overlap_module.variant_overlap → merged variant dict
-→ VCF to stdout
+merge_vcf_module_cython.merge
+  → overlap_module.{precise_overlap, insertion_svlen_match}
+  → ins_similarity.sequence_gate
+  → merged variant dict → VCF to stdout
 ```
 
 **`svdb --export`**
 ```
 SQLite → fetch_variants → coordinates
-→ dbscan.main or expand_chain/cluster_variants → representative variants
-→ vcf_line → VCF file
+  → dbscan.main or expand_chain/cluster_variants
+      expand_chain: insertion_svlen_match + ins_similarity.sequence_gate
+  → representative variant (INS: most-common ins_seq from INS table)
+  → vcf_line (INS ALT = N+ins_seq when sequence available, else <INS>)
+  → VCF file
 ```
 
 ## Packaging notes

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
     ext_modules = []
 
 setup(name='svdb',
-      version='2.10.0',
+      version='2.10.1',
       url="https://github.com/J35P312/SVDB",
       author="Jesper Eisfeldt",
       author_email="jesper.eisfeldt@scilifelab.se",

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -99,8 +99,8 @@ def main():
                             help="the prefix of the output file, default = print to stdout. Required, if multiple databases are queried")
         parser.add_argument('--bnd_distance', type=int, default=10000,
                             help="the maximum distance between two similar breakpoints(default = 10000)")
-        parser.add_argument('--ins_distance', type=int, default=50,
-                            help="the maximum distance to match two insertions(default = 50)")
+        parser.add_argument('--ins_distance', type=int, default=25,
+                            help="the maximum distance to match two insertions(default = 25)")
         parser.add_argument('--ins_svlen_ratio', type=float, default=0.90,
                             help="minimum SVLEN ratio (min/max) required to match two insertions (default = 0.90; VCF db only)")
         parser.add_argument('--ins_seq_similarity', type=float, default=None,
@@ -169,8 +169,8 @@ def main():
             '--no_merge', help="skip the merging of variants, print all variants in the db to a vcf file", required=False, action="store_true")
         parser.add_argument('--bnd_distance', type=int, default=2500,
                             help="the maximum distance between two similar precise breakpoints(default = 2500)")
-        parser.add_argument('--ins_distance', type=int, default=50,
-                            help="the maximum distance to cluster two insertions (default = 50)")
+        parser.add_argument('--ins_distance', type=int, default=25,
+                            help="the maximum distance to cluster two insertions (default = 25)")
         parser.add_argument('--ins_svlen_ratio', type=float, default=0.90,
                             help="minimum SVLEN ratio (min/max) for insertion clustering (default = 0.90; accepted but not applied — SQLite does not store SVLEN)")
         parser.add_argument('--ins_seq_similarity', type=float, default=None,

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -195,6 +195,8 @@ def main():
                             help="the prefix of the output file, default = same as input")
         parser.add_argument(
             '--memory', help="load the database into memory: increases the memory requirements, but lowers the time consumption", required=False, action="store_true")
+        parser.add_argument('--strip_chr', help="strip the 'chr' prefix from chromosome names in the output VCF",
+                            required=False, action="store_true")
         parser.add_argument('--debug', help="enable debug logging",
                             required=False, action="store_true")
         args = parser.parse_args()

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -146,6 +146,8 @@ def main():
             '--folder', type=str, help="create a db using all the vcf files in the folders")
         parser.add_argument('--prefix', type=str, default="SVDB",
                             help="the prefix of the output file, default = SVDB")
+        parser.add_argument('--upgrade', help="upgrade an existing database schema to the current SVDB version; safe to run on any database, has no effect if already up to date",
+                            required=False, action="store_true")
         parser.add_argument('--debug', help="enable debug logging",
                             required=False, action="store_true")
         args = parser.parse_args()
@@ -154,7 +156,9 @@ def main():
             logger.error("only one DB build input source may be selected (--files or --folder)")
             sys.exit(1)
 
-        if args.folder or args.files:
+        if args.upgrade:
+            build_module.main(args)
+        elif args.folder or args.files:
             build_module.main(args)
         else:
             logger.error("use --files or --folder to provide input for the database creation algorithm")

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -176,13 +176,13 @@ def main():
         parser.add_argument('--ins_distance', type=int, default=25,
                             help="the maximum distance to cluster two insertions (default = 25)")
         parser.add_argument('--ins_svlen_ratio', type=float, default=0.90,
-                            help="minimum SVLEN ratio (min/max) for insertion clustering (default = 0.90; accepted but not applied — SQLite does not store SVLEN)")
+                            help="minimum SVLEN ratio (min/max) for insertion clustering (default = 0.90; requires INS table)")
         parser.add_argument('--ins_seq_similarity', type=float, default=None,
-                            help="minimum sequence similarity for insertion clustering (accepted but not applied — SQLite does not store sequences)")
+                            help="minimum sequence similarity for insertion clustering (default = 0.75); overridden by --data_profile; requires INS table")
         parser.add_argument('--data_profile', choices=["sample", "cohort"], default=None,
-                            help="sequence similarity threshold preset (accepted but not applied for export)")
+                            help="set sequence similarity preset: sample=0.85, cohort=0.75; overrides --ins_seq_similarity; requires INS table")
         parser.add_argument(
-            '--no_ins_seq', help="disable insertion sequence gate (accepted but not applied for export)", required=False, action="store_true")
+            '--no_ins_seq', help="disable insertion sequence similarity check for clustering; requires INS table", required=False, action="store_true")
         parser.add_argument('--overlap', type=float, default=0.8,
                             help="the overlap required to merge two events(0 means anything that touches will be merged, 1 means that two events must be identical to be merged), default = 0.8")
         parser.add_argument(

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -146,7 +146,7 @@ def main():
             '--folder', type=str, help="create a db using all the vcf files in the folders")
         parser.add_argument('--prefix', type=str, default="SVDB",
                             help="the prefix of the output file, default = SVDB")
-        parser.add_argument('--upgrade', help="upgrade an existing database schema to the current SVDB version; safe to run on any database, has no effect if already up to date",
+        parser.add_argument('--upgrade', help="upgrade an existing database schema to the current SVDB version; safe to run on any database, exits with INFO if already up to date",
                             required=False, action="store_true")
         parser.add_argument('--debug', help="enable debug logging",
                             required=False, action="store_true")
@@ -190,7 +190,7 @@ def main():
         parser.add_argument('--epsilon', type=float, default=500,
                             help="used together with --DBSCAN; sets the epsilon paramter(default = 500)", required=False)
         parser.add_argument('--min_pts', type=int, default=2,
-                            help="used together with 1--DBSCAN; sets the min_pts parameter(default = 2)", required=False)
+                            help="used together with --DBSCAN; sets the min_pts parameter(default = 2)", required=False)
         parser.add_argument('--prefix', type=str, default="SVDB",
                             help="the prefix of the output file, default = same as input")
         parser.add_argument(

--- a/svdb/__main__.py
+++ b/svdb/__main__.py
@@ -102,13 +102,13 @@ def main():
         parser.add_argument('--ins_distance', type=int, default=25,
                             help="the maximum distance to match two insertions(default = 25)")
         parser.add_argument('--ins_svlen_ratio', type=float, default=0.90,
-                            help="minimum SVLEN ratio (min/max) required to match two insertions (default = 0.90; VCF db only)")
+                            help="minimum SVLEN ratio (min/max) required to match two insertions (default = 0.90); applied with --db and with --sqdb when the INS table is present; no effect with --bedpedb")
         parser.add_argument('--ins_seq_similarity', type=float, default=None,
-                            help="minimum Levenshtein sequence similarity to match two insertions (default = 0.75); overridden by --data_profile; VCF db only")
+                            help="minimum Levenshtein sequence similarity to match two insertions (default = 0.75); overridden by --data_profile; applied with --db and with --sqdb when the INS table is present; no effect with --bedpedb")
         parser.add_argument('--data_profile', choices=["sample", "cohort"], default=None,
-                            help="set sequence similarity threshold preset: sample=0.85, cohort=0.75 (VCF db only)")
+                            help="set sequence similarity threshold preset: sample=0.85, cohort=0.75; overrides --ins_seq_similarity; applied with --db and with --sqdb when the INS table is present; no effect with --bedpedb")
         parser.add_argument(
-            '--no_ins_seq', help="disable insertion sequence similarity check; match on position+SVLEN only (VCF db only)", required=False, action="store_true")
+            '--no_ins_seq', help="disable insertion sequence similarity check; match on position+SVLEN only; applied with --db and with --sqdb when the INS table is present; no effect with --bedpedb", required=False, action="store_true")
         parser.add_argument('--overlap', type=float, default=0.6,
                             help="the overlap required to merge two events(0 means anything that touches will be merged, 1 means that two events must be identical to be merged), default = 0.6")
         parser.add_argument('--memory',

--- a/svdb/build_module.py
+++ b/svdb/build_module.py
@@ -25,6 +25,8 @@ def populate_db(args):
         if sample_IDs:
             idx = 1 + int(db.query("SELECT MAX(idx) FROM SVDB")[0][0])
 
+    db.create_ins_table()
+
     # populate the tables
     for vcf in args.files:
         sample_name = Path(vcf).stem.replace(".", "_")
@@ -39,6 +41,7 @@ def populate_db(args):
             continue
 
         var = []
+        ins = []
         sample_names = []
 
         with vcf_utils.open_vcf(vcf) as lines:
@@ -76,9 +79,13 @@ def populate_db(args):
                 if "CIEND" in INFO:
                     ci_B_lower, ci_B_upper = vcf_utils.parse_ci(INFO["CIEND"])
 
+                is_ins = "INS" in event_type
+
                 if "GT" not in FORMAT or not len(sample_names):
                     var.append((event_type, chrA, chrB, posA, ci_A_lower,
                                 ci_A_upper, posB, ci_B_lower, ci_B_upper, sample_name, idx))
+                    if is_ins:
+                        ins.append((idx, variant.ins_seq or None, variant.svlen))
                     idx += 1
                 else:
                     sample_index = 0
@@ -86,12 +93,15 @@ def populate_db(args):
                         if genotype not in ["0/0", "./."]:
                             var.append((event_type, chrA, chrB, posA, ci_A_lower, ci_A_upper,
                                         posB, ci_B_lower, ci_B_upper, sample_names[sample_index], idx))
+                            if is_ins:
+                                ins.append((idx, variant.ins_seq or None, variant.svlen))
                             idx += 1
                         sample_index += 1
 
-        # insert EVERYTHING into the database, the user may then query it in different ways(at least until the DB gets to large to function properly)
         if var:
             db.insert_many(var)
+        if ins:
+            db.insert_ins_many(ins)
 
     db.create_index(name='SV', columns='(var, chrA, chrB, posA, posA, posB, posB)')
     db.create_index(name='IDX', columns='(idx)')
@@ -99,8 +109,64 @@ def populate_db(args):
     return sample_IDs
 
 
+def upgrade_db(args):
+    """Create the INS table and backfill from provided VCFs if given."""
+    db = database.DB(args.db)
+    if "SVDB" not in db.tables:
+        logger.error("no SVDB table found in %s — build a database first", args.db)
+        return
+
+    if db.has_ins_table():
+        logger.info("database schema is up to date")
+        return
+
+    db.create_ins_table()
+    logger.info("INS table created")
+
+    if not args.files and not args.folder:
+        return
+
+    # Backfill INS table from the provided VCFs by matching idx via SVDB lookup
+    ins = []
+    for vcf in args.files:
+        sample_name = Path(vcf).stem.replace(".", "_")
+        if not os.path.exists(vcf):
+            logger.warning("unable to open %s — skipping", vcf)
+            continue
+
+        with vcf_utils.open_vcf(vcf) as lines:
+            for line in lines:
+                if line.startswith("#"):
+                    continue
+                if not line.strip():
+                    continue
+
+                variant = read_vcf.readVCFLine(line)
+                if "INS" not in variant.event_type:
+                    continue
+
+                rows = db.query(
+                    f"SELECT idx FROM SVDB WHERE sample == '{sample_name}' "
+                    f"AND var == '{variant.event_type}' "
+                    f"AND chrA == '{variant.chrA}' AND posA == {variant.posA}"
+                )
+                for (idx,) in rows:
+                    ins.append((idx, variant.ins_seq or None, variant.svlen))
+
+    if ins:
+        db.insert_ins_many(ins)
+        logger.info("backfilled %d INS entries", len(ins))
+
+
 def main(args):
     args.db = args.prefix
+
+    if getattr(args, "upgrade", False):
+        if not args.files and args.folder:
+            args.files = glob.glob(os.path.join(args.folder, "*.vcf")) + glob.glob(os.path.join(args.folder, "*.vcf.gz"))
+        upgrade_db(args)
+        return
+
     if not args.files and args.folder:
         args.files = glob.glob(os.path.join(args.folder, "*.vcf")) + glob.glob(os.path.join(args.folder, "*.vcf.gz"))
         if not args.files:

--- a/svdb/build_module.py
+++ b/svdb/build_module.py
@@ -9,153 +9,153 @@ logger = logging.getLogger(__name__)
 
 
 def populate_db(args):
-    db = database.DB(args.db)
-    tables = db.tables
+    with database.DB(args.db) as db:
+        tables = db.tables
 
-    idx = 0
-    if "SVDB" not in tables:
-        db.create(database.CREATE_TABLE_SQL)
-        sample_IDs = []
-    else:
-        db.drop("DROP INDEX SV")
-        db.drop("DROP INDEX IDX")
-        db.drop("DROP INDEX CHR")
+        idx = 0
+        if "SVDB" not in tables:
+            db.create(database.CREATE_TABLE_SQL)
+            sample_IDs = []
+        else:
+            db.drop("DROP INDEX SV")
+            db.drop("DROP INDEX IDX")
+            db.drop("DROP INDEX CHR")
 
-        sample_IDs = db.sample_ids
-        if sample_IDs:
-            idx = 1 + int(db.query("SELECT MAX(idx) FROM SVDB")[0][0])
+            sample_IDs = db.sample_ids
+            if sample_IDs:
+                idx = 1 + int(db.query("SELECT MAX(idx) FROM SVDB")[0][0])
 
-    db.create_ins_table()
+        db.create_ins_table()
 
-    # populate the tables
-    for vcf in args.files:
-        sample_name = Path(vcf).stem.replace(".", "_")
-        sample_IDs.append(sample_name)
-        A = f'SELECT sample FROM SVDB WHERE sample == \'{sample_name}\' '
-        hits = [hit for hit in db.query(A)]
-        if hits:
-            logger.debug("sample %s already in database — skipping", sample_name)
-            continue
-        if not os.path.exists(vcf):
-            logger.warning("unable to open %s — skipping", vcf)
-            continue
+        # populate the tables
+        for vcf in args.files:
+            sample_name = Path(vcf).stem.replace(".", "_")
+            sample_IDs.append(sample_name)
+            A = f'SELECT sample FROM SVDB WHERE sample == \'{sample_name}\' '
+            hits = [hit for hit in db.query(A)]
+            if hits:
+                logger.debug("sample %s already in database — skipping", sample_name)
+                continue
+            if not os.path.exists(vcf):
+                logger.warning("unable to open %s — skipping", vcf)
+                continue
 
-        var = []
-        ins = []
-        sample_names = []
+            var = []
+            ins = []
+            sample_names = []
 
-        with vcf_utils.open_vcf(vcf) as lines:
-            for line in lines:
-                if line.startswith("#"):
-                    if "CHROM" in line:
-                        content = line.strip().split()
-                        if len(content) > 9:
-                            sample_names = content[9:]
-                    continue
+            with vcf_utils.open_vcf(vcf) as lines:
+                for line in lines:
+                    if line.startswith("#"):
+                        if "CHROM" in line:
+                            content = line.strip().split()
+                            if len(content) > 9:
+                                sample_names = content[9:]
+                        continue
 
-                if not len(line.strip()):
-                    continue
+                    if not len(line.strip()):
+                        continue
 
-                variant = read_vcf.readVCFLine(line)
-                if args.passonly and variant.vcf_filter not in ("PASS", "."):
-                    continue
+                    variant = read_vcf.readVCFLine(line)
+                    if args.passonly and variant.vcf_filter not in ("PASS", "."):
+                        continue
 
-                chrA = variant.chrA
-                posA = variant.posA
-                chrB = variant.chrB
-                posB = variant.posB
-                event_type = variant.event_type
-                INFO = variant.info
-                FORMAT = variant.fmt
+                    chrA = variant.chrA
+                    posA = variant.posA
+                    chrB = variant.chrB
+                    posB = variant.posB
+                    event_type = variant.event_type
+                    INFO = variant.info
+                    FORMAT = variant.fmt
 
-                ci_A_lower = 0
-                ci_A_upper = 0
-                ci_B_lower = 0
-                ci_B_upper = 0
-                if "CIPOS" in INFO:
-                    ci_A_lower, ci_A_upper = vcf_utils.parse_ci(INFO["CIPOS"])
-                    ci_B_lower, ci_B_upper = ci_A_lower, ci_A_upper
+                    ci_A_lower = 0
+                    ci_A_upper = 0
+                    ci_B_lower = 0
+                    ci_B_upper = 0
+                    if "CIPOS" in INFO:
+                        ci_A_lower, ci_A_upper = vcf_utils.parse_ci(INFO["CIPOS"])
+                        ci_B_lower, ci_B_upper = ci_A_lower, ci_A_upper
 
-                if "CIEND" in INFO:
-                    ci_B_lower, ci_B_upper = vcf_utils.parse_ci(INFO["CIEND"])
+                    if "CIEND" in INFO:
+                        ci_B_lower, ci_B_upper = vcf_utils.parse_ci(INFO["CIEND"])
 
-                is_ins = "INS" in event_type
+                    is_ins = "INS" in event_type
 
-                if "GT" not in FORMAT or not len(sample_names):
-                    var.append((event_type, chrA, chrB, posA, ci_A_lower,
-                                ci_A_upper, posB, ci_B_lower, ci_B_upper, sample_name, idx))
-                    if is_ins:
-                        ins.append((idx, variant.ins_seq or None, variant.svlen))
-                    idx += 1
-                else:
-                    sample_index = 0
-                    for genotype in FORMAT["GT"]:
-                        if genotype not in ["0/0", "./."]:
-                            var.append((event_type, chrA, chrB, posA, ci_A_lower, ci_A_upper,
-                                        posB, ci_B_lower, ci_B_upper, sample_names[sample_index], idx))
-                            if is_ins:
-                                ins.append((idx, variant.ins_seq or None, variant.svlen))
-                            idx += 1
-                        sample_index += 1
+                    if "GT" not in FORMAT or not len(sample_names):
+                        var.append((event_type, chrA, chrB, posA, ci_A_lower,
+                                    ci_A_upper, posB, ci_B_lower, ci_B_upper, sample_name, idx))
+                        if is_ins:
+                            ins.append((idx, variant.ins_seq or None, variant.svlen))
+                        idx += 1
+                    else:
+                        sample_index = 0
+                        for genotype in FORMAT["GT"]:
+                            if genotype not in ["0/0", "./."]:
+                                var.append((event_type, chrA, chrB, posA, ci_A_lower, ci_A_upper,
+                                            posB, ci_B_lower, ci_B_upper, sample_names[sample_index], idx))
+                                if is_ins:
+                                    ins.append((idx, variant.ins_seq or None, variant.svlen))
+                                idx += 1
+                            sample_index += 1
 
-        if var:
-            db.insert_many(var)
-        if ins:
-            db.insert_ins_many(ins)
+            if var:
+                db.insert_many(var)
+            if ins:
+                db.insert_ins_many(ins)
 
-    db.create_index(name='SV', columns='(var, chrA, chrB, posA, posA, posB, posB)')
-    db.create_index(name='IDX', columns='(idx)')
-    db.create_index(name='CHR', columns='(chrA, chrB)')
+        db.create_index(name='SV', columns='(var, chrA, chrB, posA, posA, posB, posB)')
+        db.create_index(name='IDX', columns='(idx)')
+        db.create_index(name='CHR', columns='(chrA, chrB)')
     return sample_IDs
 
 
 def upgrade_db(args):
     """Create the INS table and backfill from provided VCFs if given."""
-    db = database.DB(args.db)
-    if "SVDB" not in db.tables:
-        logger.error("no SVDB table found in %s — build a database first", args.db)
-        return
+    with database.DB(args.db) as db:
+        if "SVDB" not in db.tables:
+            logger.error("no SVDB table found in %s — build a database first", args.db)
+            return
 
-    if db.has_ins_table():
-        logger.info("database schema is up to date")
-        return
+        if db.has_ins_table():
+            logger.info("database schema is up to date")
+            return
 
-    db.create_ins_table()
-    logger.info("INS table created")
+        db.create_ins_table()
+        logger.info("INS table created")
 
-    if not args.files and not args.folder:
-        return
+        if not args.files and not args.folder:
+            return
 
-    # Backfill INS table from the provided VCFs by matching idx via SVDB lookup
-    ins = []
-    for vcf in args.files:
-        sample_name = Path(vcf).stem.replace(".", "_")
-        if not os.path.exists(vcf):
-            logger.warning("unable to open %s — skipping", vcf)
-            continue
+        # Backfill INS table from the provided VCFs by matching idx via SVDB lookup
+        ins = []
+        for vcf in args.files:
+            sample_name = Path(vcf).stem.replace(".", "_")
+            if not os.path.exists(vcf):
+                logger.warning("unable to open %s — skipping", vcf)
+                continue
 
-        with vcf_utils.open_vcf(vcf) as lines:
-            for line in lines:
-                if line.startswith("#"):
-                    continue
-                if not line.strip():
-                    continue
+            with vcf_utils.open_vcf(vcf) as lines:
+                for line in lines:
+                    if line.startswith("#"):
+                        continue
+                    if not line.strip():
+                        continue
 
-                variant = read_vcf.readVCFLine(line)
-                if "INS" not in variant.event_type:
-                    continue
+                    variant = read_vcf.readVCFLine(line)
+                    if "INS" not in variant.event_type:
+                        continue
 
-                rows = db.query(
-                    f"SELECT idx FROM SVDB WHERE sample == '{sample_name}' "
-                    f"AND var == '{variant.event_type}' "
-                    f"AND chrA == '{variant.chrA}' AND posA == {variant.posA}"
-                )
-                for (idx,) in rows:
-                    ins.append((idx, variant.ins_seq or None, variant.svlen))
+                    rows = db.query(
+                        f"SELECT idx FROM SVDB WHERE sample == '{sample_name}' "
+                        f"AND var == '{variant.event_type}' "
+                        f"AND chrA == '{variant.chrA}' AND posA == {variant.posA}"
+                    )
+                    for (idx,) in rows:
+                        ins.append((idx, variant.ins_seq or None, variant.svlen))
 
-    if ins:
-        db.insert_ins_many(ins)
-        logger.info("backfilled %d INS entries", len(ins))
+        if ins:
+            db.insert_ins_many(ins)
+            logger.info("backfilled %d INS entries", len(ins))
 
 
 def main(args):

--- a/svdb/database.py
+++ b/svdb/database.py
@@ -18,6 +18,12 @@ SCHEMA_COLUMNS = (
 CREATE_TABLE_SQL = "CREATE TABLE SVDB ({})".format(", ".join(SCHEMA_COLUMNS))
 INSERT_PLACEHOLDERS = "({})".format(", ".join("?" for _ in SCHEMA_COLUMNS))
 
+CREATE_INS_TABLE_SQL = (
+    "CREATE TABLE IF NOT EXISTS INS "
+    "(idx INT PRIMARY KEY, ins_seq TEXT, ins_len INT)"
+)
+INSERT_INS_PLACEHOLDERS = "(?, ?, ?)"
+
 
 class DB:
     def __init__(self, db: str, memory: bool = False) -> None:
@@ -61,6 +67,20 @@ class DB:
     def create_index(self, name: str, columns: str) -> None:
         query = f"CREATE INDEX {name} ON SVDB {columns}"
         self.cursor.execute(query)
+        self.conn.commit()
+
+    def has_ins_table(self) -> bool:
+        return "INS" in self.tables
+
+    def create_ins_table(self) -> None:
+        self.conn.execute(CREATE_INS_TABLE_SQL)
+        self.conn.commit()
+
+    def insert_ins_many(self, data: List[Tuple[Any, ...]]) -> None:
+        """Insert rows into the INS table; silently skip duplicate idx values."""
+        self.cursor.executemany(
+            f'INSERT OR IGNORE INTO INS VALUES {INSERT_INS_PLACEHOLDERS}', data
+        )
         self.conn.commit()
 
     @property

--- a/svdb/database.py
+++ b/svdb/database.py
@@ -83,6 +83,15 @@ class DB:
         )
         self.conn.commit()
 
+    def close(self) -> None:
+        self.conn.close()
+
+    def __enter__(self) -> "DB":
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()
+
     @property
     def tables(self) -> List[str]:
         return self.query_column("SELECT name FROM sqlite_master WHERE type='table'")

--- a/svdb/database.py
+++ b/svdb/database.py
@@ -37,6 +37,7 @@ class DB:
             db_dump = "".join(line for line in self.conn.iterdump())
             memory_db.executescript(db_dump)
             self.conn.close()
+            self.conn = memory_db
             self.cursor = memory_db.cursor()
         else:
             self.cursor = self.conn.cursor()

--- a/svdb/export_module.py
+++ b/svdb/export_module.py
@@ -1,14 +1,15 @@
 import logging
 import sys
+from collections import Counter
 
 import numpy as np
 
-from . import dbscan, database, overlap_module
+from . import dbscan, database, ins_similarity, overlap_module
 
 logger = logging.getLogger(__name__)
 
 
-def make_representing_variant(variant_type, chrA, chrB, posA, ci_A_start, ci_A_end, posB, ci_B_start, ci_B_end):
+def make_representing_variant(variant_type, chrA, chrB, posA, ci_A_start, ci_A_end, posB, ci_B_start, ci_B_end, ins_seq=None):
     """Build the representing-variant dict used as cluster[0] in vcf_line."""
     return {
         "type": variant_type,
@@ -20,6 +21,7 @@ def make_representing_variant(variant_type, chrA, chrB, posA, ci_A_start, ci_A_e
         "posB": posB,
         "ci_B_start": ci_B_start,
         "ci_B_end": ci_B_end,
+        "ins_seq": ins_seq,
     }
 
 
@@ -35,35 +37,59 @@ def build_genotype_columns(sample_IDs, hit_sample_ids):
 
 
 def fetch_index_variant(db, index):
-    A = 'SELECT posA, ci_A_lower, ci_A_upper, posB, ci_B_lower, ci_B_upper, sample FROM SVDB WHERE idx IN ({}) '.format(
-        ", ".join([str(idx) for idx in index]))
+    has_ins = db.has_ins_table()
+    if has_ins:
+        A = (
+            'SELECT s.posA, s.ci_A_lower, s.ci_A_upper, s.posB, s.ci_B_lower, s.ci_B_upper, '
+            's.sample, i.ins_seq, i.ins_len '
+            'FROM SVDB s LEFT JOIN INS i ON s.idx = i.idx '
+            'WHERE s.idx IN ({})'.format(", ".join([str(idx) for idx in index]))
+        )
+    else:
+        A = 'SELECT posA, ci_A_lower, ci_A_upper, posB, ci_B_lower, ci_B_upper, sample FROM SVDB WHERE idx IN ({}) '.format(
+            ", ".join([str(idx) for idx in index]))
     hits = db.query(A)
     variant = {}
     coordinates = []
     for i, hit in enumerate(hits):
-        variant[i] = {}
-        variant[i]["posA"] = int(hit[0])
-        variant[i]["ci_A_start"] = int(hit[1])
-        variant[i]["ci_A_end"] = int(hit[2])
-        variant[i]["posB"] = int(hit[3])
-        variant[i]["ci_B_start"] = int(hit[4])
-        variant[i]["ci_B_end"] = int(hit[5])
-        variant[i]["sample_id"] = hit[6]
+        variant[i] = {
+            "posA": int(hit[0]),
+            "ci_A_start": int(hit[1]),
+            "ci_A_end": int(hit[2]),
+            "posB": int(hit[3]),
+            "ci_B_start": int(hit[4]),
+            "ci_B_end": int(hit[5]),
+            "sample_id": hit[6],
+            "ins_seq": hit[7] if has_ins else None,
+            "ins_len": hit[8] if has_ins else None,
+        }
         coordinates.append([i, int(hit[0]), int(hit[3])])
     return variant, np.array(coordinates)
 
 
 def fetch_cluster_variant(db, index):
-    query = 'SELECT posA, posB, sample, idx FROM SVDB WHERE idx IN ({}) '.format(
-            ", ".join([str(idx) for idx in index]))
+    has_ins = db.has_ins_table()
+    if has_ins:
+        query = (
+            'SELECT s.posA, s.posB, s.sample, s.idx, i.ins_seq, i.ins_len '
+            'FROM SVDB s LEFT JOIN INS i ON s.idx = i.idx '
+            'WHERE s.idx IN ({})'.format(", ".join([str(idx) for idx in index]))
+        )
+    else:
+        query = 'SELECT posA, posB, sample, idx FROM SVDB WHERE idx IN ({}) '.format(
+                ", ".join([str(idx) for idx in index]))
     hits = db.query(query)
 
     variant_dict = {}
     for hit in hits:
-        variant_dict[int(hit[3])] = {}
-        variant_dict[int(hit[3])]["posA"] = int(hit[0])
-        variant_dict[int(hit[3])]["posB"] = int(hit[1])
-        variant_dict[int(hit[3])]["sample_id"] = hit[2]
+        i = int(hit[3])
+        variant_dict[i] = {
+            "posA": int(hit[0]),
+            "posB": int(hit[1]),
+            "sample_id": hit[2],
+            "ins_seq": hit[4] if has_ins else None,
+            "ins_len": hit[5] if has_ins else None,
+        }
     return variant_dict
 
 
@@ -96,9 +122,15 @@ def vcf_line(cluster, id_tag, sample_IDs):
     vcf_line.append(str(cluster[0]["posA"]))
     vcf_line.append(id_tag)
     vcf_line.append("N")
+    is_ins = cluster[0]["type"] == "INS" and cluster[0]["chrA"] == cluster[0]["chrB"]
     if cluster[0]["chrA"] == cluster[0]["chrB"] and cluster[0]["type"] != "BND":
-        vcf_line.append("<" + cluster[0]["type"] + ">")
-        info_field += "END={};SVLEN={};".format(cluster[0]["posB"], abs(cluster[0]["posA"] - cluster[0]["posB"]))
+        ins_seq = cluster[0].get("ins_seq")
+        if is_ins and ins_seq:
+            vcf_line.append("N" + ins_seq)
+            info_field += "SVLEN={};".format(len(ins_seq))
+        else:
+            vcf_line.append("<" + cluster[0]["type"] + ">")
+            info_field += "END={};SVLEN={};".format(cluster[0]["posB"], abs(cluster[0]["posA"] - cluster[0]["posB"]))
     else:
         vcf_line.append("N[{}:{}[".format(cluster[0]["chrB"], cluster[0]["posB"]))
 
@@ -132,11 +164,13 @@ def vcf_line(cluster, id_tag, sample_IDs):
     return "\t".join(vcf_line)
 
 
-def expand_chain(chain, coordinates, chrA, chrB, distance, overlap):
+def expand_chain(chain, coordinates, chrA, chrB, distance, overlap,
+                 ins_svlen_ratio=None, ins_seq_threshold=None, no_ins_seq=False):
+    is_ins = chrA == chrB and overlap == -1
     chain_data = {}
-    for i,idx in enumerate(chain):
+    for i, idx in enumerate(chain):
         chain_data[i] = []
-        variant=chain[idx]
+        variant = chain[idx]
 
         rows = coordinates[(distance >= abs(coordinates[:, 1] - variant["posA"]))
                            & (distance >= abs(coordinates[:, 2] - variant["posB"]))]
@@ -146,9 +180,26 @@ def expand_chain(chain, coordinates, chrA, chrB, distance, overlap):
             var = chain[candidate]
             if chrA != chrB:
                 match = True
+            elif is_ins:
+                _, match = overlap_module.precise_overlap(
+                    variant["posA"], variant["posB"], var["posA"], var["posB"], distance)
             else:
                 _, match = overlap_module.isSameVariation(
                     variant["posA"], variant["posB"], var["posA"], var["posB"], overlap, distance)
+
+            if match and is_ins and ins_svlen_ratio is not None:
+                len_a = variant.get("ins_len")
+                len_b = var.get("ins_len")
+                if len_a is not None and len_b is not None:
+                    if not overlap_module.insertion_svlen_match(len_a, len_b, ins_svlen_ratio):
+                        match = False
+
+            if match and is_ins and not no_ins_seq and ins_seq_threshold is not None:
+                seq_a = variant.get("ins_seq") or ""
+                seq_b = var.get("ins_seq") or ""
+                if not ins_similarity.sequence_gate(seq_a, seq_b, ins_seq_threshold):
+                    match = False
+
             if match:
                 chain_data[i].append(candidate)
 
@@ -191,11 +242,22 @@ def fetch_variants(variant, chrA, chrB, db):
     return chr_db
 
 
+def _pick_ins_seq(variant_dict):
+    """Return the most common non-null ins_seq across the cluster, or None."""
+    seqs = [v.get("ins_seq") for v in variant_dict.values() if v.get("ins_seq")]
+    if not seqs:
+        return None
+    return Counter(seqs).most_common(1)[0][0]
+
+
 def overlap_cluster(db, indexes, variant, chrA, chrB, sample_IDs, args, f, i):
     variant_dictionary, coordinates = fetch_index_variant(db, indexes)
     if "INS" in variant:
         similarity_matrix = expand_chain(
-           variant_dictionary, coordinates, chrA, chrB, args.ins_distance, -1)
+            variant_dictionary, coordinates, chrA, chrB, args.ins_distance, -1,
+            ins_svlen_ratio=getattr(args, "ins_svlen_ratio", None),
+            ins_seq_threshold=getattr(args, "ins_seq_similarity", None),
+            no_ins_seq=getattr(args, "no_ins_seq", False))
     else:
         similarity_matrix = expand_chain(
            variant_dictionary, coordinates, chrA, chrB, args.bnd_distance, args.overlap)
@@ -205,6 +267,8 @@ def overlap_cluster(db, indexes, variant, chrA, chrB, sample_IDs, args, f, i):
         clustered_variants[0]["type"] = variant
         clustered_variants[0]["chrA"] = chrA
         clustered_variants[0]["chrB"] = chrB
+        if "ins_seq" not in clustered_variants[0]:
+            clustered_variants[0]["ins_seq"] = _pick_ins_seq(clustered_variants[1])
         f.write(vcf_line(clustered_variants, f"cluster_{i}", sample_IDs) + "\n")
     return i + len(clusters)
 
@@ -230,8 +294,9 @@ def svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f):
     unique_index = chr_db[variant]["index"][labels == -1]
     for xy, indexes in zip(unique_xy, unique_index):
         variant_dictionary = fetch_cluster_variant(db, [indexes])
+        ins_seq = _pick_ins_seq(variant_dictionary)
         representing_var = make_representing_variant(
-            variant, chrA, chrB, xy[0], xy[0], xy[0], xy[1], xy[1], xy[1])
+            variant, chrA, chrB, xy[0], xy[0], xy[0], xy[1], xy[1], xy[1], ins_seq)
         cluster = [representing_var, variant_dictionary]
         f.write(vcf_line(cluster, f"cluster_{i}", sample_IDs) + "\n")
         i += 1
@@ -250,11 +315,13 @@ def svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f):
             avg_point = np.array([np.mean(xy[:, 0]), np.mean(xy[:, 1])])
 
             variant_dictionary = fetch_cluster_variant(db, indexes)
+            ins_seq = _pick_ins_seq(variant_dictionary)
 
             representing_var = make_representing_variant(
                 variant, chrA, chrB,
                 int(avg_point[0]), np.amin(xy[:, 0]), np.amax(xy[:, 0]),
-                int(avg_point[1]), np.amin(xy[:, 1]), np.amax(xy[:, 1]))
+                int(avg_point[1]), np.amin(xy[:, 1]), np.amax(xy[:, 1]),
+                ins_seq)
             cluster = [representing_var, variant_dictionary]
             f.write(vcf_line(cluster, f"cluster_{i}", sample_IDs) + "\n")
             i += 1
@@ -267,11 +334,19 @@ def svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f):
 
 
 def export(args, sample_IDs):
+    args.ins_seq_similarity = ins_similarity.resolve_ins_seq_threshold(args)
     db = database.DB(args.db, memory=args.memory)
 
     chrA_list = db.query_column('SELECT DISTINCT chrA FROM SVDB')
     chrB_list = db.query_column('SELECT DISTINCT chrB FROM SVDB')
     var_list = db.query_column('SELECT DISTINCT var FROM SVDB')
+
+    if any("INS" in v for v in var_list) and not db.has_ins_table():
+        logger.warning(
+            "database does not contain insertion sequence/length data — "
+            "exporting insertions without sequence in ALT column. "
+            "To enable full insertion export, run: svdb --build --upgrade --files <original_vcfs>"
+        )
 
     i = 0
     with open(args.prefix + ".vcf", 'a') as f:

--- a/svdb/export_module.py
+++ b/svdb/export_module.py
@@ -267,8 +267,7 @@ def overlap_cluster(db, indexes, variant, chrA, chrB, sample_IDs, args, f, i):
         clustered_variants[0]["type"] = variant
         clustered_variants[0]["chrA"] = chrA
         clustered_variants[0]["chrB"] = chrB
-        if "ins_seq" not in clustered_variants[0]:
-            clustered_variants[0]["ins_seq"] = _pick_ins_seq(clustered_variants[1])
+        clustered_variants[0]["ins_seq"] = _pick_ins_seq(clustered_variants[1])
         f.write(vcf_line(clustered_variants, f"cluster_{i}", sample_IDs) + "\n")
     return i + len(clusters)
 

--- a/svdb/export_module.py
+++ b/svdb/export_module.py
@@ -334,25 +334,24 @@ def svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f):
 
 def export(args, sample_IDs):
     args.ins_seq_similarity = ins_similarity.resolve_ins_seq_threshold(args)
-    db = database.DB(args.db, memory=args.memory)
+    with database.DB(args.db, memory=args.memory) as db:
+        chrA_list = db.query_column('SELECT DISTINCT chrA FROM SVDB')
+        chrB_list = db.query_column('SELECT DISTINCT chrB FROM SVDB')
+        var_list = db.query_column('SELECT DISTINCT var FROM SVDB')
 
-    chrA_list = db.query_column('SELECT DISTINCT chrA FROM SVDB')
-    chrB_list = db.query_column('SELECT DISTINCT chrB FROM SVDB')
-    var_list = db.query_column('SELECT DISTINCT var FROM SVDB')
+        if any("INS" in v for v in var_list) and not db.has_ins_table():
+            logger.warning(
+                "database does not contain insertion sequence/length data — "
+                "exporting insertions without sequence in ALT column. "
+                "To enable full insertion export, run: svdb --build --upgrade --files <original_vcfs>"
+            )
 
-    if any("INS" in v for v in var_list) and not db.has_ins_table():
-        logger.warning(
-            "database does not contain insertion sequence/length data — "
-            "exporting insertions without sequence in ALT column. "
-            "To enable full insertion export, run: svdb --build --upgrade --files <original_vcfs>"
-        )
-
-    i = 0
-    with open(args.prefix + ".vcf", 'a') as f:
-        for chrA in chrA_list:
-            for chrB in chrB_list:
-                for variant in var_list:
-                    i = svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f)
+        i = 0
+        with open(args.prefix + ".vcf", 'a') as f:
+            for chrA in chrA_list:
+                for chrB in chrB_list:
+                    for variant in var_list:
+                        i = svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f)
 
 
 def main(args):
@@ -360,9 +359,8 @@ def main(args):
     if not args.prefix:
         args.prefix = args.db.replace(".db", "")
 
-    db = database.DB(args.db)
-
-    sample_IDs = db.query_column('SELECT DISTINCT sample FROM SVDB')
+    with database.DB(args.db) as db:
+        sample_IDs = db.query_column('SELECT DISTINCT sample FROM SVDB')
 
     with open(args.prefix + ".vcf", 'w') as f:
         f.write(db_header(args) + "\n")

--- a/svdb/export_module.py
+++ b/svdb/export_module.py
@@ -5,6 +5,7 @@ from collections import Counter
 import numpy as np
 
 from . import dbscan, database, ins_similarity, overlap_module
+from .vcf_utils import normalize_chrom
 
 logger = logging.getLogger(__name__)
 
@@ -115,10 +116,11 @@ def db_header(args):
     return headerString
 
 
-def vcf_line(cluster, id_tag, sample_IDs):
+def vcf_line(cluster, id_tag, sample_IDs, strip_chr=False):
+    _chrom = normalize_chrom if strip_chr else (lambda x: x)
     info_field = "SVTYPE={};".format(cluster[0]["type"])
     vcf_line = []
-    vcf_line.append(cluster[0]["chrA"])
+    vcf_line.append(_chrom(cluster[0]["chrA"]))
     vcf_line.append(str(cluster[0]["posA"]))
     vcf_line.append(id_tag)
     vcf_line.append("N")
@@ -132,7 +134,7 @@ def vcf_line(cluster, id_tag, sample_IDs):
             vcf_line.append("<" + cluster[0]["type"] + ">")
             info_field += "END={};SVLEN={};".format(cluster[0]["posB"], abs(cluster[0]["posA"] - cluster[0]["posB"]))
     else:
-        vcf_line.append("N[{}:{}[".format(cluster[0]["chrB"], cluster[0]["posB"]))
+        vcf_line.append("N[{}:{}[".format(_chrom(cluster[0]["chrB"]), cluster[0]["posB"]))
 
     sample_set = set([])
     CIPOS = []
@@ -262,13 +264,14 @@ def overlap_cluster(db, indexes, variant, chrA, chrB, sample_IDs, args, f, i):
         similarity_matrix = expand_chain(
            variant_dictionary, coordinates, chrA, chrB, args.bnd_distance, args.overlap)
 
+    strip_chr = getattr(args, "strip_chr", False)
     clusters = cluster_variants(variant_dictionary, similarity_matrix)
     for clustered_variants in clusters:
         clustered_variants[0]["type"] = variant
         clustered_variants[0]["chrA"] = chrA
         clustered_variants[0]["chrB"] = chrB
         clustered_variants[0]["ins_seq"] = _pick_ins_seq(clustered_variants[1])
-        f.write(vcf_line(clustered_variants, f"cluster_{i}", sample_IDs) + "\n")
+        f.write(vcf_line(clustered_variants, f"cluster_{i}", sample_IDs, strip_chr) + "\n")
     return i + len(clusters)
 
 
@@ -287,6 +290,7 @@ def svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f):
         #clustering of all other variants
         labels = dbscan.main(chr_db[variant]["coordinates"], args.bnd_distance, 2)
 
+    strip_chr = getattr(args, "strip_chr", False)
     unique_labels = set(labels)
     # print the unique variants
     unique_xy = chr_db[variant]["coordinates"][labels == -1]
@@ -297,7 +301,7 @@ def svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f):
         representing_var = make_representing_variant(
             variant, chrA, chrB, xy[0], xy[0], xy[0], xy[1], xy[1], xy[1], ins_seq)
         cluster = [representing_var, variant_dictionary]
-        f.write(vcf_line(cluster, f"cluster_{i}", sample_IDs) + "\n")
+        f.write(vcf_line(cluster, f"cluster_{i}", sample_IDs, strip_chr) + "\n")
         i += 1
     del unique_xy
     del unique_index
@@ -322,7 +326,7 @@ def svdb_cluster_main(chrA, chrB, variant, sample_IDs, args, db, i, f):
                 int(avg_point[1]), np.amin(xy[:, 1]), np.amax(xy[:, 1]),
                 ins_seq)
             cluster = [representing_var, variant_dictionary]
-            f.write(vcf_line(cluster, f"cluster_{i}", sample_IDs) + "\n")
+            f.write(vcf_line(cluster, f"cluster_{i}", sample_IDs, strip_chr) + "\n")
             i += 1
 
         else:

--- a/svdb/merge_vcf_module_cython.py
+++ b/svdb/merge_vcf_module_cython.py
@@ -126,12 +126,35 @@ def sort_format_field(line, samples, sample_order, priority_order, files, args):
 
     if not args.same_order:
         sorted_samples = sorted(samples)  # constant across all input_files — compute once
+
+        # Pass 1: build FORMAT entries union from ALL callers so lower-priority tags are not dropped
+        for input_file in priority_order:
+            if input_file not in files:
+                continue
+            vcf_line = files[input_file].strip().split("\t")
+            if len(vcf_line) <= 8:
+                continue
+            entries = vcf_line[8].split(":")
+            # find a reference sample value to estimate comma-count (multi-value width)
+            ref_sample_entries = []
+            for sample in sorted_samples:
+                if input_file in sample_order.get(sample, {}):
+                    pos = sample_order[sample][input_file]
+                    if 9 + pos < len(vcf_line):
+                        ref_sample_entries = vcf_line[9 + pos].split(":")
+                        break
+            for i, entry in enumerate(entries):
+                if entry not in format_entries:
+                    n = ref_sample_entries[i].count(",") if i < len(ref_sample_entries) else 0
+                    format_entries.append(entry)
+                    format_entry_length.append(n)
+
+        # Pass 2: collect per-sample values from highest-priority caller
         for input_file in priority_order:
             if input_file not in files:
                 continue
             for sample in sorted_samples:
                 if sample not in format_columns and input_file in sample_order[sample]:
-
                     vcf_line = files[input_file].strip().split("\t")
                     sample_position = sample_order[sample][input_file]
                     if 9 + sample_position >= len(vcf_line):
@@ -139,42 +162,27 @@ def sort_format_field(line, samples, sample_order, priority_order, files, args):
                     format_columns[sample] = {}
                     entries = vcf_line[8].split(":")
                     sample_entries = vcf_line[9 + sample_position].split(":")
-
                     for i, entry in enumerate(entries):
                         format_columns[sample][entry] = sample_entries[i] if i < len(sample_entries) else "."
-                        if entry not in format_entries:
-                            n = sample_entries[i].count(",")
-                            format_entries.append(entry)
-                            format_entry_length.append(n)
 
         if len(line) > 8:
-            format_string = []
             line[8] = ":".join(format_entries)
             del line[9:]
             for sample in samples:
                 format_string = []
-                for entry in format_entries:
-                    j = 0
+                for j, entry in enumerate(format_entries):
                     if sample in format_columns:
                         if entry in format_columns[sample]:
                             format_string.append(format_columns[sample][entry])
                         elif entry == "GT":
                             format_string.append("./.")
                         else:
-                            sub_entry = []
-                            for i in range(format_entry_length[j] + 1):
-                                sub_entry.append(".")
-                            format_string.append(",".join(sub_entry))
+                            format_string.append(",".join("." for _ in range(format_entry_length[j] + 1)))
                     else:
                         if entry == "GT":
                             format_string.append("./.")
                         else:
-                            sub_entry = []
-                            for i in range(format_entry_length[j] + 1):
-                                sub_entry.append(".")
-                            format_string.append(",".join(sub_entry))
-                    j += 1
-
+                            format_string.append(",".join("." for _ in range(format_entry_length[j] + 1)))
                 line.append(":".join(format_string))
 
     # generate a union of the info fields

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -205,23 +205,23 @@ def main(args, output_file=None):
         return None
 
     elif args.sqdb:
-        db = database.DB(db=args.sqdb, memory=args.memory)
-        db_size = len(db)
-        if not db_size:
-            logger.error("no samples found in the database")
-            sys.exit(1)
+        with database.DB(db=args.sqdb, memory=args.memory) as db:
+            db_size = len(db)
+            if not db_size:
+                logger.error("no samples found in the database")
+                sys.exit(1)
 
-        has_ins_queries = any("INS" in q[4] for q in queries)
-        has_ins_table = db.has_ins_table()
-        if has_ins_queries and not has_ins_table:
-            logger.warning(
-                "database does not contain insertion sequence/length data — "
-                "matching on position only. To enable full insertion matching, "
-                "run: svdb --build --upgrade --files <original_vcfs>"
-            )
+            has_ins_queries = any("INS" in q[4] for q in queries)
+            has_ins_table = db.has_ins_table()
+            if has_ins_queries and not has_ins_table:
+                logger.warning(
+                    "database does not contain insertion sequence/length data — "
+                    "matching on position only. To enable full insertion matching, "
+                    "run: svdb --build --upgrade --files <original_vcfs>"
+                )
 
-        for query in queries:
-            query[5] = SQDB(query, args, db, has_ins_table)
+            for query in queries:
+                query[5] = SQDB(query, args, db, has_ins_table)
 
         _write_sqdb_results(queries, args, writer, db_size)
 

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -212,7 +212,8 @@ def main(args, output_file=None):
             sys.exit(1)
 
         has_ins_queries = any("INS" in q[4] for q in queries)
-        if has_ins_queries and not db.has_ins_table():
+        has_ins_table = db.has_ins_table()
+        if has_ins_queries and not has_ins_table:
             logger.warning(
                 "database does not contain insertion sequence/length data — "
                 "matching on position only. To enable full insertion matching, "
@@ -220,7 +221,7 @@ def main(args, output_file=None):
             )
 
         for query in queries:
-            query[5] = SQDB(query, args, db)
+            query[5] = SQDB(query, args, db, has_ins_table)
 
         _write_sqdb_results(queries, args, writer, db_size)
 
@@ -324,7 +325,7 @@ def queryVCFDB(DBvariants, query_variant, args, use_OCC_tag):
     return hits
 
 
-def SQDB(query_variant, args, db):
+def SQDB(query_variant, args, db, has_ins_table=False):
     is_ins = "INS" in query_variant[4]
     distance = getattr(args, "ins_distance", 25) if is_ins else args.bnd_distance
     overlap = args.overlap
@@ -332,7 +333,7 @@ def SQDB(query_variant, args, db):
                "chrA": query_variant[0], "posA": query_variant[1],
                "chrB": query_variant[2], "posB": query_variant[3]}
 
-    use_ins_table = is_ins and db.has_ins_table() and not getattr(args, "no_ins_seq", False)
+    use_ins_table = is_ins and has_ins_table and not getattr(args, "no_ins_seq", False)
 
     if use_ins_table:
         selection = "s.posA, s.posB, s.sample, s.idx, i.ins_seq, i.ins_len"

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -339,8 +339,6 @@ def SQDB(query_variant, args, db, has_ins_table=False):
         selection = "s.posA, s.posB, s.sample, s.idx, i.ins_seq, i.ins_len"
         join = "LEFT JOIN INS i ON s.idx = i.idx"
         table = "SVDB s"
-        chr_filter = "s.var"
-        pos_filter = "s.chrA, s.chrB, s.posA, s.posB"
         A = (
             f"SELECT {selection} FROM {table} {join} "
             f"WHERE s.var == '{variant['type']}' AND s.chrA == '{variant['chrA']}' "
@@ -371,7 +369,7 @@ def SQDB(query_variant, args, db, has_ins_table=False):
             hit_posA, hit_posB, hit_sample = int(hit[0]), int(hit[1]), hit[2]
             if use_ins_table:
                 hit_idx, hit_seq, hit_len = hit[3], hit[4], hit[5]
-                similar, _ = overlap_module.precise_overlap(
+                _, similar = overlap_module.precise_overlap(
                     variant["posA"], variant["posB"], hit_posA, hit_posB, distance)
                 if similar and hit_len is not None and query_svlen is not None:
                     if not overlap_module.insertion_svlen_match(query_svlen, hit_len, ins_svlen_ratio):
@@ -383,7 +381,7 @@ def SQDB(query_variant, args, db, has_ins_table=False):
                 if similar:
                     match.add(hit_idx)
             elif is_ins:
-                similar, _ = overlap_module.precise_overlap(
+                _, similar = overlap_module.precise_overlap(
                     variant["posA"], variant["posB"], hit_posA, hit_posB, distance)
                 if similar:
                     match.add(hit_sample)

--- a/svdb/query_module.py
+++ b/svdb/query_module.py
@@ -211,6 +211,14 @@ def main(args, output_file=None):
             logger.error("no samples found in the database")
             sys.exit(1)
 
+        has_ins_queries = any("INS" in q[4] for q in queries)
+        if has_ins_queries and not db.has_ins_table():
+            logger.warning(
+                "database does not contain insertion sequence/length data — "
+                "matching on position only. To enable full insertion matching, "
+                "run: svdb --build --upgrade --files <original_vcfs>"
+            )
+
         for query in queries:
             query[5] = SQDB(query, args, db)
 
@@ -318,33 +326,71 @@ def queryVCFDB(DBvariants, query_variant, args, use_OCC_tag):
 
 def SQDB(query_variant, args, db):
     is_ins = "INS" in query_variant[4]
-    # Use ins_distance for insertions — bnd_distance is too loose for single-point INS events
-    distance = getattr(args, "ins_distance", 50) if is_ins else args.bnd_distance
+    distance = getattr(args, "ins_distance", 25) if is_ins else args.bnd_distance
     overlap = args.overlap
     variant = {"type": query_variant[4],
                "chrA": query_variant[0], "posA": query_variant[1],
                "chrB": query_variant[2], "posB": query_variant[3]}
 
-    selection = "posA, posB, sample" if variant["chrA"] == variant["chrB"] else "sample"
+    use_ins_table = is_ins and db.has_ins_table() and not getattr(args, "no_ins_seq", False)
 
-    A = 'SELECT {} FROM SVDB WHERE var == \'{}\' AND chrA == \'{}\' AND chrB == \'{}\' AND posA <= {} AND posA >= {} AND posB <= {} AND posB >= {}'.format(
-        selection, variant["type"], variant["chrA"], variant["chrB"],
-        variant["posA"] + distance, variant["posA"] - distance,
-        variant["posB"] + distance, variant["posB"] - distance)
+    if use_ins_table:
+        selection = "s.posA, s.posB, s.sample, s.idx, i.ins_seq, i.ins_len"
+        join = "LEFT JOIN INS i ON s.idx = i.idx"
+        table = "SVDB s"
+        chr_filter = "s.var"
+        pos_filter = "s.chrA, s.chrB, s.posA, s.posB"
+        A = (
+            f"SELECT {selection} FROM {table} {join} "
+            f"WHERE s.var == '{variant['type']}' AND s.chrA == '{variant['chrA']}' "
+            f"AND s.chrB == '{variant['chrB']}' "
+            f"AND s.posA <= {variant['posA'] + distance} AND s.posA >= {variant['posA'] - distance} "
+            f"AND s.posB <= {variant['posB'] + distance} AND s.posB >= {variant['posB'] - distance}"
+        )
+    else:
+        selection = "posA, posB, sample" if variant["chrA"] == variant["chrB"] else "sample"
+        A = (
+            f"SELECT {selection} FROM SVDB "
+            f"WHERE var == '{variant['type']}' AND chrA == '{variant['chrA']}' "
+            f"AND chrB == '{variant['chrB']}' "
+            f"AND posA <= {variant['posA'] + distance} AND posA >= {variant['posA'] - distance} "
+            f"AND posB <= {variant['posB'] + distance} AND posB >= {variant['posB'] - distance}"
+        )
+
     hits = db.query(A)
 
-    match = set([])
+    ins_svlen_ratio = getattr(args, "ins_svlen_ratio", 0.90)
+    ins_seq_threshold = getattr(args, "ins_seq_similarity", 0.75)
+    query_seq = query_variant[7] if is_ins else ""
+    query_svlen = query_variant[8] if is_ins else None
+
+    match = set()
     for hit in hits:
         if variant["chrA"] == variant["chrB"]:
-            hit_posA, hit_posB, hit_idx = int(hit[0]), int(hit[1]), hit[2]
-            if is_ins:
+            hit_posA, hit_posB, hit_sample = int(hit[0]), int(hit[1]), hit[2]
+            if use_ins_table:
+                hit_idx, hit_seq, hit_len = hit[3], hit[4], hit[5]
                 similar, _ = overlap_module.precise_overlap(
                     variant["posA"], variant["posB"], hit_posA, hit_posB, distance)
+                if similar and hit_len is not None and query_svlen is not None:
+                    if not overlap_module.insertion_svlen_match(query_svlen, hit_len, ins_svlen_ratio):
+                        similar = False
+                pos_dist = abs(variant["posA"] - hit_posA)
+                if similar and pos_dist <= _INS_SEQ_HARD_CAP:
+                    if not ins_similarity.sequence_gate(query_seq, hit_seq or "", ins_seq_threshold):
+                        similar = False
+                if similar:
+                    match.add(hit_idx)
+            elif is_ins:
+                similar, _ = overlap_module.precise_overlap(
+                    variant["posA"], variant["posB"], hit_posA, hit_posB, distance)
+                if similar:
+                    match.add(hit_sample)
             else:
                 similar, _ = overlap_module.isSameVariation(
                     variant["posA"], variant["posB"], hit_posA, hit_posB, overlap, distance)
-            if similar:
-                match.add(hit_idx)
+                if similar:
+                    match.add(hit_sample)
         else:
             match.add(hit[0])
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,13 +7,13 @@ from svdb.database import DB, CREATE_TABLE_SQL
 def db(tmp_path):
     """In-memory-equivalent DB backed by a temp file, pre-populated with two rows."""
     path = str(tmp_path / "test")
-    d = DB(path)
-    d.create(CREATE_TABLE_SQL)
-    d.insert_many([
-        ("DEL", "1", "1", 100, 0, 0, 200, 0, 0, "sample_A", 0),
-        ("INS", "2", "2", 500, 0, 0, 500, 0, 0, "sample_B", 1),
-    ])
-    return d
+    with DB(path) as d:
+        d.create(CREATE_TABLE_SQL)
+        d.insert_many([
+            ("DEL", "1", "1", 100, 0, 0, 200, 0, 0, "sample_A", 0),
+            ("INS", "2", "2", 500, 0, 0, 500, 0, 0, "sample_B", 1),
+        ])
+        yield d
 
 
 class TestDBQueryColumn:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,6 +1,6 @@
 import unittest
 
-from svdb.export_module import db_header, make_representing_variant, build_genotype_columns
+from svdb.export_module import db_header, make_representing_variant, build_genotype_columns, vcf_line as make_vcf_line
 
 #mock argeparse arguments
 class args:
@@ -51,3 +51,32 @@ class TestBuildGenotypeColumns(unittest.TestCase):
     def test_order_follows_sample_ids(self):
         cols = build_genotype_columns(["b", "a"], ["a"])
         assert cols == ["0/0", "./1"]
+
+
+class TestVcfLineStripChr(unittest.TestCase):
+
+    def _cluster(self, chrA, chrB, vtype="DEL"):
+        rep = make_representing_variant(vtype, chrA, chrB, 100, 100, 100, 200, 200, 200)
+        variants = {0: {"posA": 100, "posB": 200, "sample_id": "s1"}}
+        return [rep, variants]
+
+    def test_chr_prefix_preserved_by_default(self):
+        line = make_vcf_line(self._cluster("chr1", "chr1"), "id1", ["s1"])
+        assert line.startswith("chr1\t")
+
+    def test_strip_chr_removes_prefix(self):
+        line = make_vcf_line(self._cluster("chr1", "chr1"), "id1", ["s1"], strip_chr=True)
+        assert line.startswith("1\t")
+
+    def test_strip_chr_bnd_chrB(self):
+        rep = make_representing_variant("BND", "chr1", "chr2", 100, 100, 100, 500, 500, 500)
+        cluster = [rep, {0: {"posA": 100, "posB": 500, "sample_id": "s1"}}]
+        line = make_vcf_line(cluster, "id1", ["s1"], strip_chr=True)
+        fields = line.split("\t")
+        assert fields[0] == "1"
+        assert "chr2" not in fields[4]
+        assert "2:" in fields[4]
+
+    def test_no_chr_prefix_unaffected(self):
+        line = make_vcf_line(self._cluster("1", "1"), "id1", ["s1"], strip_chr=True)
+        assert line.startswith("1\t")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,6 +1,7 @@
+import argparse
 import unittest
 
-from svdb.merge_vcf_module_cython import collect_info, skip_variant, collect_sample, sanitize_id, format_tag
+from svdb.merge_vcf_module_cython import collect_info, skip_variant, collect_sample, sanitize_id, format_tag, sort_format_field
 
 
 class TestSanitizeId(unittest.TestCase):
@@ -84,6 +85,68 @@ class TestMerge(unittest.TestCase):
         #Skip filtered variants (if pass_only =True)
         result=skip_variant(chrA,"X",type_A,type_B,vcf_line_A,vcf_line_B,True,current_variant,analysed_variants,True)
         assert (result)
+
+
+class TestSortFormatField(unittest.TestCase):
+
+    def _args(self):
+        return argparse.Namespace(same_order=False)
+
+    def test_format_union_includes_lower_priority_tags(self):
+        """Lower-priority caller's unique FORMAT tags must appear in the merged FORMAT."""
+        # manta (priority 1): FORMAT GT:GQ
+        manta = "chr1\t100\t.\tN\t<DEL>\t.\tPASS\tSVTYPE=DEL\tGT:GQ\t0/1:30"
+        # lumpy (priority 2): FORMAT GT:SU — SU is lumpy-specific
+        lumpy = "chr1\t100\t.\tN\t<DEL>\t.\tPASS\tSVTYPE=DEL\tGT:SU\t0/1:15"
+
+        samples = ["sample_A"]
+        sample_order = {"sample_A": {"manta.vcf": 0, "lumpy.vcf": 0}}
+        priority_order = ["manta.vcf", "lumpy.vcf"]
+        files = {"manta.vcf": manta, "lumpy.vcf": lumpy}
+        line = manta.split("\t")
+
+        result = sort_format_field(line, samples, sample_order, priority_order, files, self._args())
+
+        fmt_keys = result[8].split(":")
+        assert "GT" in fmt_keys
+        assert "GQ" in fmt_keys
+        assert "SU" in fmt_keys, "lumpy-specific SU tag was dropped (pre-fix regression)"
+
+        # sample values: GT and GQ come from manta; SU not in manta → "."
+        vals = result[9].split(":")
+        assert vals[fmt_keys.index("GT")] == "0/1"
+        assert vals[fmt_keys.index("GQ")] == "30"
+        assert vals[fmt_keys.index("SU")] == "."
+
+    def test_format_placeholder_uses_correct_width(self):
+        """Missing multi-value FORMAT entry produces the right number of '.' placeholders."""
+        # caller1 (priority 1): sample_A with FORMAT GT:AD, AD is 3-value
+        c1 = "chr1\t100\t.\tN\t<DEL>\t.\tPASS\tSVTYPE=DEL\tGT:AD\t0/1:10,20,5"
+        # caller2 (priority 2): sample_B with FORMAT GT:DP
+        c2 = "chr1\t100\t.\tN\t<DEL>\t.\tPASS\tSVTYPE=DEL\tGT:DP\t0/1:30"
+
+        samples = ["sample_A", "sample_B"]
+        sample_order = {"sample_A": {"c1.vcf": 0}, "sample_B": {"c2.vcf": 0}}
+        priority_order = ["c1.vcf", "c2.vcf"]
+        files = {"c1.vcf": c1, "c2.vcf": c2}
+        line = c1.split("\t")
+
+        result = sort_format_field(line, samples, sample_order, priority_order, files, self._args())
+
+        fmt_keys = result[8].split(":")
+        assert fmt_keys == ["GT", "AD", "DP"]
+
+        # sample_A: GT=0/1, AD=10,20,5 from c1; DP missing → "."
+        a = result[9].split(":")
+        assert a[fmt_keys.index("GT")] == "0/1"
+        assert a[fmt_keys.index("AD")] == "10,20,5"
+        assert a[fmt_keys.index("DP")] == "."
+
+        # sample_B: GT=0/1, DP=30 from c2; AD missing → ".,.,." (3 values, not ".")
+        b = result[10].split(":")
+        assert b[fmt_keys.index("GT")] == "0/1"
+        assert b[fmt_keys.index("AD")] == ".,.,.", "j=0 bug: AD placeholder width used wrong index"
+        assert b[fmt_keys.index("DP")] == "30"
 
 
 

--- a/tests/test_sqlite_ins.py
+++ b/tests/test_sqlite_ins.py
@@ -211,6 +211,80 @@ class TestQuerySQLiteINS:
         assert len(lines) == 1
         assert "OCC=1" in lines[0]
 
+    def test_query_svlen_ratio_blocks_dissimilar_length(self, tmp_path):
+        """SVLEN ratio gate: DB SVLEN=80, query SVLEN=100 → ratio=0.80 < default 0.90."""
+        db_vcf = tmp_path / "db.vcf"
+        query_vcf = tmp_path / "query.vcf"
+        make_ins_vcf(db_vcf, [("1", 1000, "db_ins", "A" * 80)])
+        make_ins_vcf(query_vcf, [("1", 1000, "q_ins", "A" * 100)])
+        build(tmp_path / "svdb", db_vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                "--query_vcf", str(query_vcf))
+        assert r.returncode == 0
+        lines = data_lines(r.stdout)
+        assert len(lines) == 1
+        assert "OCC=" not in lines[0]
+
+    def test_query_svlen_ratio_permissive_allows_match(self, tmp_path):
+        """Lowering --ins_svlen_ratio lets the same pair through."""
+        db_vcf = tmp_path / "db.vcf"
+        query_vcf = tmp_path / "query.vcf"
+        make_ins_vcf(db_vcf, [("1", 1000, "db_ins", "A" * 80)])
+        make_ins_vcf(query_vcf, [("1", 1000, "q_ins", "A" * 100)])
+        build(tmp_path / "svdb", db_vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                "--query_vcf", str(query_vcf), "--ins_svlen_ratio", "0.75")
+        assert r.returncode == 0
+        lines = data_lines(r.stdout)
+        assert len(lines) == 1
+        assert "OCC=1" in lines[0]
+
+    def test_query_ins_distance_blocks_far_insertion(self, tmp_path):
+        """Insertion 30 bp away is outside the default ins_distance=25 window."""
+        db_vcf = tmp_path / "db.vcf"
+        query_vcf = tmp_path / "query.vcf"
+        make_ins_vcf(db_vcf, [("1", 1000, "db_ins", "ACGTACGT")])
+        make_ins_vcf(query_vcf, [("1", 1030, "q_ins", "ACGTACGT")])
+        build(tmp_path / "svdb", db_vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                "--query_vcf", str(query_vcf))
+        assert r.returncode == 0
+        lines = data_lines(r.stdout)
+        assert len(lines) == 1
+        assert "OCC=" not in lines[0]
+
+    def test_query_ins_distance_custom_allows_far_insertion(self, tmp_path):
+        """--ins_distance 50 brings a 30 bp gap within range."""
+        db_vcf = tmp_path / "db.vcf"
+        query_vcf = tmp_path / "query.vcf"
+        make_ins_vcf(db_vcf, [("1", 1000, "db_ins", "ACGTACGT")])
+        make_ins_vcf(query_vcf, [("1", 1030, "q_ins", "ACGTACGT")])
+        build(tmp_path / "svdb", db_vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                "--query_vcf", str(query_vcf), "--ins_distance", "50")
+        assert r.returncode == 0
+        lines = data_lines(r.stdout)
+        assert len(lines) == 1
+        assert "OCC=1" in lines[0]
+
+    def test_query_data_profile_sample_blocks_moderate_similarity(self, tmp_path):
+        """--data_profile sample sets threshold=0.85; sequence with sim≈0.80 should not match."""
+        db_vcf = tmp_path / "db.vcf"
+        query_vcf = tmp_path / "query.vcf"
+        # 50 A's in DB; 40 A's + 10 C's in query → Levenshtein sim = 1 - 10/50 = 0.80
+        make_ins_vcf(db_vcf, [("1", 1000, "db_ins", "A" * 50)])
+        make_ins_vcf(query_vcf, [("1", 1000, "q_ins", "A" * 40 + "C" * 10)])
+        build(tmp_path / "svdb", db_vcf)
+        # Default threshold 0.75: sim 0.80 passes → should match
+        r_default = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                        "--query_vcf", str(query_vcf))
+        assert "OCC=1" in data_lines(r_default.stdout)[0]
+        # sample profile threshold 0.85: sim 0.80 fails → should not match
+        r_profile = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                        "--query_vcf", str(query_vcf), "--data_profile", "sample")
+        assert r_profile.returncode == 0
+        assert "OCC=" not in data_lines(r_profile.stdout)[0]
+
 
 # ---------------------------------------------------------------------------
 # Export: ALT column + warning
@@ -276,3 +350,81 @@ class TestExportINS:
         lines = data_lines((tmp_path / "out.vcf").read_text())
         # All four cluster together (--no_ins_seq); most common seq is ACGTACGT
         assert any("NACGTACGT" in line for line in lines)
+
+    def test_export_ins_svlen_ratio_separates_different_lengths(self, tmp_path):
+        """Default ratio=0.90 keeps very different lengths in separate clusters."""
+        vcf = tmp_path / "sample.vcf"
+        # ratio = 20/100 = 0.20, well below default 0.90
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "A" * 20),
+            ("1", 1001, "ins2", "A" * 100),
+        ])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"), "--no_ins_seq")
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        assert len(lines) == 2
+
+    def test_export_ins_svlen_ratio_permissive_merges_different_lengths(self, tmp_path):
+        """Lowering --ins_svlen_ratio lets differently-sized insertions cluster."""
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "A" * 20),
+            ("1", 1001, "ins2", "A" * 100),
+        ])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"),
+                "--no_ins_seq", "--ins_svlen_ratio", "0.10")
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        assert len(lines) == 1
+
+    def test_export_ins_distance_separates_far_insertions(self, tmp_path):
+        """Two insertions 30 bp apart stay separate with the default ins_distance=25."""
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "ACGTACGT"),
+            ("1", 1030, "ins2", "ACGTACGT"),
+        ])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"))
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        assert len(lines) == 2
+
+    def test_export_ins_distance_custom_merges_far_insertions(self, tmp_path):
+        """--ins_distance 50 brings two insertions 30 bp apart into the same cluster."""
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "ACGTACGT"),
+            ("1", 1030, "ins2", "ACGTACGT"),
+        ])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"), "--ins_distance", "50")
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        assert len(lines) == 1
+
+    def test_export_data_profile_sample_separates_moderate_similarity(self, tmp_path):
+        """--data_profile sample (threshold=0.85) keeps sim≈0.80 insertions separate."""
+        vcf = tmp_path / "sample.vcf"
+        # 50 A's vs 40 A's + 10 C's → Levenshtein sim = 1 - 10/50 = 0.80
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "A" * 50),
+            ("1", 1001, "ins2", "A" * 40 + "C" * 10),
+        ])
+        build(tmp_path / "svdb", vcf)
+        # Default threshold 0.75: sim 0.80 passes → one cluster
+        run("--export", "--db", str(tmp_path / "svdb.db"),
+            "--prefix", str(tmp_path / "out_default"))
+        assert len(data_lines((tmp_path / "out_default.vcf").read_text())) == 1
+        # sample profile threshold 0.85: sim 0.80 fails → two clusters
+        r_profile = run("--export", "--db", str(tmp_path / "svdb.db"),
+                        "--prefix", str(tmp_path / "out_profile"),
+                        "--data_profile", "sample")
+        assert r_profile.returncode == 0
+        assert len(data_lines((tmp_path / "out_profile.vcf").read_text())) == 2

--- a/tests/test_sqlite_ins.py
+++ b/tests/test_sqlite_ins.py
@@ -1,0 +1,278 @@
+"""End-to-end tests for the SQLite INS table feature.
+
+Covers: build populates INS table, --upgrade on old/current DBs, query --sqdb
+warning + sequence gates, export ALT column with sequence vs symbolic fallback.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from svdb.database import DB, CREATE_TABLE_SQL
+
+FIXTURES = Path(__file__).parent / "fixtures"
+DEL_VCF = FIXTURES / "manta_chr1_del.vcf"
+SVDB = [sys.executable, "-m", "svdb"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_ins_vcf(path: Path, variants: list) -> None:
+    """Write a minimal single-sample INS VCF.
+
+    variants: list of (chrom, pos, id, sequence) tuples.
+    """
+    lines = [
+        "##fileformat=VCFv4.1",
+        '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of SV">',
+        '##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="SV length">',
+        '##INFO=<ID=END,Number=1,Type=Integer,Description="End position">',
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO",
+    ]
+    for chrom, pos, id_, seq in variants:
+        lines.append(
+            f"{chrom}\t{pos}\t{id_}\tN\tN{seq}\t.\tPASS\t"
+            f"SVTYPE=INS;SVLEN={len(seq)};END={pos}"
+        )
+    path.write_text("\n".join(lines) + "\n")
+
+
+def make_old_db(prefix: Path, svdb_rows: list) -> None:
+    """Create a database with only the SVDB table (no INS table) — simulates pre-upgrade DB."""
+    db = DB(str(prefix))
+    db.create(CREATE_TABLE_SQL)
+    db.insert_many(svdb_rows)
+
+
+def build(prefix: Path, *vcfs: Path) -> None:
+    subprocess.run(
+        SVDB + ["--build", "--files"] + [str(v) for v in vcfs] + ["--prefix", str(prefix)],
+        capture_output=True, check=True,
+    )
+
+
+def run(*args) -> subprocess.CompletedProcess:
+    return subprocess.run(SVDB + list(args), capture_output=True, text=True)
+
+
+def data_lines(text: str) -> list:
+    return [line for line in text.splitlines() if line and not line.startswith("#")]
+
+
+# ---------------------------------------------------------------------------
+# Build: INS table population
+# ---------------------------------------------------------------------------
+
+class TestBuildINSTable:
+
+    def test_build_creates_ins_table(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGTACGT")])
+        build(tmp_path / "svdb", vcf)
+        assert DB(str(tmp_path / "svdb")).has_ins_table()
+
+    def test_build_populates_ins_seq_and_len(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGTACGT")])
+        build(tmp_path / "svdb", vcf)
+        db = DB(str(tmp_path / "svdb"))
+        rows = db.query("SELECT ins_seq, ins_len FROM INS")
+        assert len(rows) == 1
+        assert rows[0][0] == "ACGTACGT"
+        assert rows[0][1] == 8
+
+    def test_build_del_variants_not_in_ins_table(self, tmp_path):
+        build(tmp_path / "svdb", DEL_VCF)
+        db = DB(str(tmp_path / "svdb"))
+        assert db.has_ins_table()
+        assert db.query("SELECT COUNT(*) FROM INS")[0][0] == 0
+
+    def test_build_multiple_ins_variants_all_stored(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "ACGT"),
+            ("1", 2000, "ins2", "TTTT"),
+            ("1", 3000, "ins3", "CCCC"),
+        ])
+        build(tmp_path / "svdb", vcf)
+        db = DB(str(tmp_path / "svdb"))
+        assert db.query("SELECT COUNT(*) FROM INS")[0][0] == 3
+
+
+# ---------------------------------------------------------------------------
+# --upgrade
+# ---------------------------------------------------------------------------
+
+class TestUpgrade:
+
+    def test_upgrade_creates_ins_table_on_old_db(self, tmp_path):
+        prefix = tmp_path / "svdb"
+        make_old_db(prefix, [("INS", "1", "1", 1000, 0, 0, 1000, 0, 0, "sample_A", 0)])
+        assert not DB(str(prefix)).has_ins_table()
+
+        r = run("--build", "--upgrade", "--prefix", str(prefix))
+        assert r.returncode == 0
+        assert "INS table created" in r.stderr
+        assert DB(str(prefix)).has_ins_table()
+
+    def test_upgrade_idempotent_when_already_current(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGT")])
+        build(tmp_path / "svdb", vcf)
+
+        r = run("--build", "--upgrade", "--prefix", str(tmp_path / "svdb"))
+        assert r.returncode == 0
+        assert "up to date" in r.stderr
+
+    def test_upgrade_with_files_backfills_ins_data(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGTACGT")])
+        # build old DB without INS table, with one matching SVDB row
+        make_old_db(tmp_path / "svdb", [
+            ("INS", "1", "1", 1000, 0, 0, 1000, 0, 0, "sample", 0)
+        ])
+
+        r = run("--build", "--upgrade", "--files", str(vcf), "--prefix", str(tmp_path / "svdb"))
+        assert r.returncode == 0
+
+        db = DB(str(tmp_path / "svdb"))
+        rows = db.query("SELECT ins_seq, ins_len FROM INS")
+        assert len(rows) == 1
+        assert rows[0][0] == "ACGTACGT"
+        assert rows[0][1] == 8
+
+    def test_upgrade_on_missing_db_exits_gracefully(self, tmp_path):
+        r = run("--build", "--upgrade", "--prefix", str(tmp_path / "nonexistent"))
+        assert r.returncode == 0
+        assert "no SVDB table" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Query --sqdb: warning + sequence gates
+# ---------------------------------------------------------------------------
+
+class TestQuerySQLiteINS:
+
+    def test_query_warns_when_ins_table_absent(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGT")])
+        make_old_db(tmp_path / "svdb", [
+            ("INS", "1", "1", 1000, 0, 0, 1000, 0, 0, "sample_A", 0)
+        ])
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"), "--query_vcf", str(vcf))
+        assert r.returncode == 0
+        assert "does not contain insertion sequence" in r.stderr
+
+    def test_query_no_warning_when_ins_table_present(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGT")])
+        build(tmp_path / "svdb", vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"), "--query_vcf", str(vcf))
+        assert r.returncode == 0
+        assert "does not contain insertion sequence" not in r.stderr
+
+    def test_query_counts_matching_insertion(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGTACGT")])
+        build(tmp_path / "svdb", vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"), "--query_vcf", str(vcf))
+        assert r.returncode == 0
+        lines = data_lines(r.stdout)
+        assert len(lines) == 1
+        assert "OCC=1" in lines[0]
+
+    def test_query_sequence_gate_blocks_dissimilar_insertion(self, tmp_path):
+        """Completely different sequence at same position should not be counted."""
+        db_vcf = tmp_path / "db.vcf"
+        query_vcf = tmp_path / "query.vcf"
+        make_ins_vcf(db_vcf, [("1", 1000, "db_ins", "AAAAAAAAAAAAAAAA")])
+        make_ins_vcf(query_vcf, [("1", 1000, "q_ins", "CCCCCCCCCCCCCCCC")])
+        build(tmp_path / "svdb", db_vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                "--query_vcf", str(query_vcf), "--ins_seq_similarity", "0.75")
+        assert r.returncode == 0
+        lines = data_lines(r.stdout)
+        assert len(lines) == 1
+        assert "OCC=" not in lines[0]
+
+    def test_query_no_ins_seq_skips_sequence_gate(self, tmp_path):
+        """--no_ins_seq should match on position only, ignoring dissimilar sequences."""
+        db_vcf = tmp_path / "db.vcf"
+        query_vcf = tmp_path / "query.vcf"
+        make_ins_vcf(db_vcf, [("1", 1000, "db_ins", "AAAAAAAAAAAAAAAA")])
+        make_ins_vcf(query_vcf, [("1", 1000, "q_ins", "CCCCCCCCCCCCCCCC")])
+        build(tmp_path / "svdb", db_vcf)
+        r = run("--query", "--sqdb", str(tmp_path / "svdb.db"),
+                "--query_vcf", str(query_vcf), "--no_ins_seq")
+        assert r.returncode == 0
+        lines = data_lines(r.stdout)
+        assert len(lines) == 1
+        assert "OCC=1" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Export: ALT column + warning
+# ---------------------------------------------------------------------------
+
+class TestExportINS:
+
+    def test_export_alt_uses_sequence_when_ins_table_present(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        # two identical insertions to form a cluster
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "ACGTACGT"),
+            ("1", 1001, "ins2", "ACGTACGT"),
+        ])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"))
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        assert any("NACGTACGT" in line for line in lines)
+
+    def test_export_alt_falls_back_to_symbolic_without_ins_table(self, tmp_path):
+        make_old_db(tmp_path / "svdb", [
+            ("INS", "1", "1", 1000, 0, 0, 1000, 0, 0, "sample_A", 0)
+        ])
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"))
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        assert any("<INS>" in line for line in lines)
+
+    def test_export_warns_when_ins_table_absent(self, tmp_path):
+        make_old_db(tmp_path / "svdb", [
+            ("INS", "1", "1", 1000, 0, 0, 1000, 0, 0, "sample_A", 0)
+        ])
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"))
+        assert r.returncode == 0
+        assert "does not contain insertion sequence" in r.stderr
+
+    def test_export_no_warning_when_ins_table_present(self, tmp_path):
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGT")])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"))
+        assert r.returncode == 0
+        assert "does not contain insertion sequence" not in r.stderr
+
+    def test_export_cluster_representative_uses_most_common_sequence(self, tmp_path):
+        """Three identical sequences vs one different — most common should win."""
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "ACGTACGT"),
+            ("1", 1001, "ins2", "ACGTACGT"),
+            ("1", 1002, "ins3", "ACGTACGT"),
+            ("1", 1003, "ins4", "TTTTTTTT"),
+        ])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"), "--no_ins_seq")
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        # All four cluster together (--no_ins_seq); most common seq is ACGTACGT
+        assert any("NACGTACGT" in line for line in lines)

--- a/tests/test_sqlite_ins.py
+++ b/tests/test_sqlite_ins.py
@@ -41,9 +41,9 @@ def make_ins_vcf(path: Path, variants: list) -> None:
 
 def make_old_db(prefix: Path, svdb_rows: list) -> None:
     """Create a database with only the SVDB table (no INS table) — simulates pre-upgrade DB."""
-    db = DB(str(prefix))
-    db.create(CREATE_TABLE_SQL)
-    db.insert_many(svdb_rows)
+    with DB(str(prefix)) as db:
+        db.create(CREATE_TABLE_SQL)
+        db.insert_many(svdb_rows)
 
 
 def build(prefix: Path, *vcfs: Path) -> None:
@@ -71,23 +71,24 @@ class TestBuildINSTable:
         vcf = tmp_path / "sample.vcf"
         make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGTACGT")])
         build(tmp_path / "svdb", vcf)
-        assert DB(str(tmp_path / "svdb")).has_ins_table()
+        with DB(str(tmp_path / "svdb")) as db:
+            assert db.has_ins_table()
 
     def test_build_populates_ins_seq_and_len(self, tmp_path):
         vcf = tmp_path / "sample.vcf"
         make_ins_vcf(vcf, [("1", 1000, "ins1", "ACGTACGT")])
         build(tmp_path / "svdb", vcf)
-        db = DB(str(tmp_path / "svdb"))
-        rows = db.query("SELECT ins_seq, ins_len FROM INS")
+        with DB(str(tmp_path / "svdb")) as db:
+            rows = db.query("SELECT ins_seq, ins_len FROM INS")
         assert len(rows) == 1
         assert rows[0][0] == "ACGTACGT"
         assert rows[0][1] == 8
 
     def test_build_del_variants_not_in_ins_table(self, tmp_path):
         build(tmp_path / "svdb", DEL_VCF)
-        db = DB(str(tmp_path / "svdb"))
-        assert db.has_ins_table()
-        assert db.query("SELECT COUNT(*) FROM INS")[0][0] == 0
+        with DB(str(tmp_path / "svdb")) as db:
+            assert db.has_ins_table()
+            assert db.query("SELECT COUNT(*) FROM INS")[0][0] == 0
 
     def test_build_multiple_ins_variants_all_stored(self, tmp_path):
         vcf = tmp_path / "sample.vcf"
@@ -97,8 +98,8 @@ class TestBuildINSTable:
             ("1", 3000, "ins3", "CCCC"),
         ])
         build(tmp_path / "svdb", vcf)
-        db = DB(str(tmp_path / "svdb"))
-        assert db.query("SELECT COUNT(*) FROM INS")[0][0] == 3
+        with DB(str(tmp_path / "svdb")) as db:
+            assert db.query("SELECT COUNT(*) FROM INS")[0][0] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -110,12 +111,14 @@ class TestUpgrade:
     def test_upgrade_creates_ins_table_on_old_db(self, tmp_path):
         prefix = tmp_path / "svdb"
         make_old_db(prefix, [("INS", "1", "1", 1000, 0, 0, 1000, 0, 0, "sample_A", 0)])
-        assert not DB(str(prefix)).has_ins_table()
+        with DB(str(prefix)) as db:
+            assert not db.has_ins_table()
 
         r = run("--build", "--upgrade", "--prefix", str(prefix))
         assert r.returncode == 0
         assert "INS table created" in r.stderr
-        assert DB(str(prefix)).has_ins_table()
+        with DB(str(prefix)) as db:
+            assert db.has_ins_table()
 
     def test_upgrade_idempotent_when_already_current(self, tmp_path):
         vcf = tmp_path / "sample.vcf"
@@ -137,8 +140,8 @@ class TestUpgrade:
         r = run("--build", "--upgrade", "--files", str(vcf), "--prefix", str(tmp_path / "svdb"))
         assert r.returncode == 0
 
-        db = DB(str(tmp_path / "svdb"))
-        rows = db.query("SELECT ins_seq, ins_len FROM INS")
+        with DB(str(tmp_path / "svdb")) as db:
+            rows = db.query("SELECT ins_seq, ins_len FROM INS")
         assert len(rows) == 1
         assert rows[0][0] == "ACGTACGT"
         assert rows[0][1] == 8


### PR DESCRIPTION
The branch adds a second SQLite table (INS) alongside the existing SVDB table so that insertion sequences and lengths are stored in the database and used during query and export. It also cleans up the issue #82 documentation that was missing from the previous merge.

## Schema (database.py)
- New INS(idx INT PRIMARY KEY, ins_seq TEXT, ins_len INT) table, keyed on the same idx as SVDB - no changes to the existing 11-column SVDB schema
- New DB methods: has_ins_table(), create_ins_table(), insert_ins_many()
- DB now implements close() / __enter__ / __exit__ so all call sites use with DB(...) as db: - fixes a ResourceWarning that appeared on Python 3.12+ including CI on 3.14
##  Build (build_module.py, __main__.py)
- populate_db creates the INS table on every new build and populates it with (idx, ins_seq, ins_len) for every insertion variant
- New upgrade_db function and --upgrade flag:
    - Schema-only: svdb --build --upgrade --prefix existing_db creates the INS table on an old database (idempotent, exits with INFO if already current)
    - With backfill: svdb --build --upgrade --files original.vcf --prefix existing_db additionally matches INS rows back to SVDB via sample+position lookup and populates the INS table
##  Query (query_module.py)
- SQDB now does a LEFT JOIN INS when the INS table is present, applying SVLEN ratio and sequence-similarity gates (same thresholds as the VCF-db path)
- Fixed precise_overlap unpacking bug: return order is (distance, is_match) but was unpacked as (match, _) - exact-position matches (distance=0.0) never fired
- Warns once per invocation when querying insertions against a database without the INS table
- All four insertion flags (--ins_svlen_ratio, --ins_seq_similarity, --data_profile, --no_ins_seq) now apply to both --db and --sqdb (when INS table present); --bedpedb unaffected
##  Export (export_module.py)
- fetch_index_variant and fetch_cluster_variant do a LEFT JOIN INS when the INS table is present, carrying ins_seq and ins_len into the clustering pipeline
- expand_chain applies SVLEN ratio and sequence-similarity gates for insertions (using precise_overlap, consistent with merge and query)
- _pick_ins_seq: majority-vote (Counter.most_common) representative sequence for a cluster
- vcf_line emits N + ins_seq in the ALT column for insertions with a known sequence; falls back to <INS> when INS table is absent
- resolve_ins_seq_threshold called at the top of export() so --data_profile is honoured
- Warns once when exporting insertions from a database without the INS table
- Fixed unconditional _pick_ins_seq assignment in overlap_cluster (was guarded by a key-presence check that always passed)
## Documentation
- README: Build section documents --upgrade and --passonly; Export section documents all five insertion flags; Query section corrected; --ins_distance default harmonised to 25 everywhere
- docs/architecture.md: ins_similarity added to module table and dependency graph; VCFVariant, MergeVariant, DB class diagrams updated; data-flow sections rewritten for all four commands including the new --upgrade subcommand
## Tests 
tests/test_sqlite_ins.py - 31 new tests

## Bugs

- FORMAT union bug (the reported issue): The original code built format_entries inside the per-sample loop guarded by if sample not in format_columns. Once a sample was claimed by its highest-priority caller, lower-priority callers never contributed their FORMAT tags. Fix: added a dedicated Pass 1 that iterates all callers unconditionally and collects the FORMAT entries union — independently of per-sample tracking.
- `j = 0` index bug: In the output generation loop, j was reset to 0 at the top of every iteration (j = 0 inside for entry in format_entries:), so format_entry_length[j] always read index 0. This produced wrong-width "." placeholders for missing multi-value entries at any position after the first. Fix: replaced with for j, entry in enumerate(format_entries):.



Resolves #86, #75 and #58