### PR TITLE
Remove normalise_chrom when reading vcfs

### DIFF
--- a/svdb/read_vcf.py
+++ b/svdb/read_vcf.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 
 from .ins_similarity import extract_ins_sequence
 from .models import VCFVariant
-from .vcf_utils import normalize_chrom, parse_info_field
+from .vcf_utils import parse_info_field
 
 
 def readVCFLine(line: str) -> Optional[VCFVariant]:
@@ -12,7 +12,7 @@ def readVCFLine(line: str) -> Optional[VCFVariant]:
 
     variation = line.strip().split("\t")
     event_type = ""
-    chrA = normalize_chrom(variation[0])
+    chrA = variation[0]
     posA = int(variation[1])
     posB = 0
 
@@ -99,7 +99,7 @@ def readVCFLine(line: str) -> Optional[VCFVariant]:
 
         bnd_parts = re.split("[],[]", B)
         chr_and_pos = bnd_parts[1]
-        chrB = normalize_chrom(":".join(chr_and_pos.split(":")[:-1]))
+        chrB = ":".join(chr_and_pos.split(":")[:-1])
         posB = int(chr_and_pos.split(":")[-1])
         if chrA > chrB:
             chrT = chrA

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -123,6 +123,47 @@ class TestExport:
 
 
 # ---------------------------------------------------------------------------
+# Export — strip_chr
+# ---------------------------------------------------------------------------
+
+_CHR_VCF_CONTENT = """\
+##fileformat=VCFv4.1
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample1
+chr1\t1000\tsv1\tN\t<DEL>\t.\tPASS\tSVTYPE=DEL;END=5000\tGT\t0/1
+"""
+
+
+class TestExportStripChr:
+    @pytest.fixture
+    def chr_db(self, tmp_path):
+        vcf = tmp_path / "chr_sample.vcf"
+        vcf.write_text(_CHR_VCF_CONTENT)
+        prefix = tmp_path / "svdb"
+        run("--build", "--files", str(vcf), "--prefix", str(prefix))
+        return tmp_path / "svdb.db"
+
+    def test_chr_prefix_preserved_without_flag(self, chr_db, tmp_path):
+        """Without --strip_chr, exported CHROM column keeps the chr prefix."""
+        prefix = tmp_path / "out"
+        r = run("--export", "--db", str(chr_db), "--prefix", str(prefix))
+        assert r.returncode == 0
+        lines = vcf_data_lines((tmp_path / "out.vcf").read_text())
+        assert all(line.startswith("chr") for line in lines)
+
+    def test_strip_chr_removes_prefix(self, chr_db, tmp_path):
+        """With --strip_chr, exported CHROM column has no chr prefix."""
+        prefix = tmp_path / "out"
+        r = run("--export", "--db", str(chr_db), "--strip_chr", "--prefix", str(prefix))
+        assert r.returncode == 0
+        lines = vcf_data_lines((tmp_path / "out.vcf").read_text())
+        assert len(lines) > 0
+        assert all(not line.startswith("chr") for line in lines)
+
+
+# ---------------------------------------------------------------------------
 # Query — VCF db
 # ---------------------------------------------------------------------------
 

--- a/tests/test_readvcf.py
+++ b/tests/test_readvcf.py
@@ -122,3 +122,20 @@ class TestReadVCFLine(unittest.TestCase):
         assert v.posA == 1000
         assert v.posB == 5000
 
+    # --- chr prefix preservation (strip_chr is export-time only) ---
+
+    def test_chr_prefix_preserved_del(self):
+        """chr prefix in CHROM is stored as-is; stripping only happens at export with --strip_chr."""
+        line = 'chr1\t1000\t.\tN\t<DEL>\t.\tPASS\tEND=5000;SVTYPE=DEL\tGT\t0/1'
+        v = readVCFLine(line)
+        assert v.chrA == "chr1"
+        assert v.chrB == "chr1"
+
+    def test_chr_prefix_preserved_bnd(self):
+        """chr prefix in both chrA and chrB of a BND record is preserved."""
+        line = 'chr1\t1000\t.\tN\t]chr2:5000]N\t.\tPASS\tSVTYPE=BND\tGT\t0/1'
+        v = readVCFLine(line)
+        assert v.chrA == "chr1"
+        assert v.chrB == "chr2"
+        assert v.posB == 5000
+


### PR DESCRIPTION
The recent addition of --strip_chr to export command would indicate that the 'chr' prefix can be optionally stripped when exporting to vcf. However, the current behaviour of build command is to strip 'chr' prefix using normalise_chrom function when vcfs are being read, meaning that the --strip_chr option is redundant if the database never has a 'chr' prefix.

This pull-request removes normalise_chrom from the  readVCFLine function. This way one has the option to strip the chr prefix during export using --strip_chr, or keep them if --strip_chr is not used. 

The unit and integration tests added were generated using Claude.