### PR TITLE
Pick INS cluster representative as medoid, not arbitrary highest-degree row

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -63,16 +63,27 @@ collapsed by one of two algorithms:
 Sort variants by degree (overlapping neighbours) descending.
 For each variant, highest-degree first:
     if already marked as non-representative: skip
-    otherwise: become representative
+    otherwise: become the claiming anchor
         for each neighbour:
             mark neighbour as non-representative
             add neighbour to this cluster
+        representative row = medoid of the cluster (see below)
 ```
 
 Marking a variant as non-representative only prevents it from *starting* a
 new cluster — it does not exclude it from being collected by other active
 representatives whose neighbour list includes it.  A variant that overlaps
 two separate representatives therefore contributes to both clusters.
+
+**Representative row selection**: the highest-degree variant only decides
+*membership* (which neighbours get claimed). The row actually used for the
+exported `POS`/`SVLEN`/`ALT` is the cluster's **medoid** — a real member whose
+own `ins_seq` already equals the cluster's consensus sequence — falling back
+to the highest-degree row when the cluster has no single consensus (mixed or
+symbolic membership). Without this, the exported line could stitch together
+an unrelated high-degree anchor's position with a different row's sequence,
+making two clusters anchored by different minority alleles look like
+duplicates once both happened to converge on the same displayed consensus.
 
 **Properties**: fast; no transitivity (A-B and B-C do not force A and C into
 the same cluster). A variant in an ambiguous region between two groups
@@ -93,7 +104,9 @@ Union-Find (disjoint-set) structure:
 ```text
 For every overlapping pair (i, j):
     union(i, j)
-Collect connected components; representative = highest-degree member.
+Collect connected components; representative = medoid of the component
+(falls back to highest-degree member when there's no single consensus
+sequence — see "Representative row selection" above).
 ```
 
 **Properties**: A-B and B-C always merge {A, B, C} even if A and C do not

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,15 @@ overlaps multiple representatives appears in each cluster so OCC reflects all
 groups it genuinely belongs to. `union_find`: transitive closure, exclusive
 membership, fewer larger clusters.
 
+**Representative row** (`_pick_representative`, both `star` and `union_find`):
+degree only decides which variant *claims* a cluster's membership. The row
+actually used for the exported `POS`/`SVLEN`/`ALT` is the cluster's medoid —
+a real member whose own `ins_seq` already matches the cluster's consensus
+sequence — falling back to the degree-based anchor when the cluster has no
+single consensus (mixed/symbolic membership). This keeps the exported line
+self-consistent: without it, `POS` could come from one row while `ALT` came
+from a majority vote over a completely different row's sequence.
+
 **`--coarse`**: skips Pass 2 entirely; centroid + most-common ins_seq/len from
 the DBSCAN group directly. Controlled by `--epsilon`/`--min_pts`.
 

--- a/svdb/export_module.py
+++ b/svdb/export_module.py
@@ -283,10 +283,28 @@ def expand_chain(chain, coordinates, chrA, chrB, distance, overlap,
     return chain_data
 
 
+def _pick_representative(fallback_idx, cluster_dictionary):
+    """Return the chain index to use as a cluster's representative.
+
+    Degree-based claiming decides *membership*; this decides which member's
+    own row gets displayed as POS/SVLEN/ALT. Prefers the medoid — an actual
+    member whose own ins_seq already equals the cluster's consensus sequence
+    (_pick_ins_seq) — so the exported representative is self-consistent with
+    one real row instead of stitching an unrelated high-degree anchor's
+    position onto a different row's sequence. Falls back to fallback_idx
+    (the degree-based anchor) when the cluster has no single consensus
+    sequence (mixed/symbolic membership).
+    """
+    consensus_seq = _pick_ins_seq(cluster_dictionary)
+    if consensus_seq is None:
+        return fallback_idx
+    return next(m for m in cluster_dictionary if cluster_dictionary[m].get("ins_seq") == consensus_seq)
+
+
 def cluster_variants(variant_dictionary, similarity_matrix):
     """Greedy star clustering (default).
 
-    Highest-degree variant becomes representative and claims its neighbours.
+    Highest-degree variant claims its neighbours to decide membership.
     A variant that overlaps multiple representatives contributes to each of
     their clusters — intentional, so OCC/FRQ reflect all groups it belongs to.
     No transitivity: A-B and B-C do not force A and C into the same cluster.
@@ -303,7 +321,7 @@ def cluster_variants(variant_dictionary, similarity_matrix):
         for var in similarity_matrix[i]:
             similarity_matrix[var][0] = -1
             cluster_dictionary[var] = variant_dictionary[var]
-        variant = variant_dictionary[i]
+        variant = variant_dictionary[_pick_representative(i, cluster_dictionary)]
 
         clusters.append([variant, cluster_dictionary])
     return clusters
@@ -315,7 +333,8 @@ def cluster_variants_union_find(variant_dictionary, similarity_matrix):
     Full transitive closure of the overlap graph: A-B and B-C always merge
     A, B, C into one component even if A and C don't overlap directly.
     Structurally prevents duplicate membership.  Representative is the
-    highest-degree member of each component.
+    medoid of each component (see _pick_representative), falling back to
+    the highest-degree member when there's no single consensus sequence.
     """
     n = len(variant_dictionary)
     parent = list(range(n))
@@ -347,8 +366,9 @@ def cluster_variants_union_find(variant_dictionary, similarity_matrix):
 
     clusters = []
     for members in components.values():
-        rep = max(members, key=lambda x: len(similarity_matrix[x]))
+        fallback = max(members, key=lambda x: len(similarity_matrix[x]))
         cluster_dict = {m: variant_dictionary[m] for m in members}
+        rep = _pick_representative(fallback, cluster_dict)
         clusters.append([variant_dictionary[rep], cluster_dict])
     return clusters
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -10,7 +10,7 @@ from svdb.export_module import (
     _expand_and_cluster_worker, _resolve_workers,
     db_header, make_representing_variant, build_genotype_columns,
     vcf_line as make_vcf_line,
-    _pick_ins_seq,
+    _pick_ins_seq, _pick_representative,
 )
 
 #mock argeparse arguments
@@ -337,6 +337,81 @@ class TestClusterVariantsUnionFind(unittest.TestCase):
         self.assertEqual(len(clusters), 1)
         # representative posA should be variant 1's posA=150
         self.assertEqual(clusters[0][0]["posA"], 150)
+
+
+class TestPickRepresentative(unittest.TestCase):
+    """Representative selection prefers the medoid (a real member whose own
+    ins_seq matches the cluster's consensus) over the degree-based anchor,
+    so POS/SVLEN/ALT come from one self-consistent row instead of stitching
+    together an unrelated high-degree row's position with a different row's
+    sequence -- the exact failure traced in issue #93/#95.
+    """
+
+    def test_prefers_medoid_over_high_degree_row_with_different_sequence(self):
+        """Regression case: the highest-degree row is a minority sequence;
+        the medoid (majority sequence) should win as representative instead.
+        """
+        cluster_dictionary = {
+            0: {"posA": 999, "ins_seq": "MINORITY_BUT_HIGH_DEGREE"},
+            1: {"posA": 100, "ins_seq": "MAJORITY"},
+            2: {"posA": 101, "ins_seq": "MAJORITY"},
+            3: {"posA": 102, "ins_seq": "MAJORITY"},
+        }
+        # fallback_idx (0) is deliberately NOT the medoid -- mirrors a
+        # degree-based anchor that doesn't carry the consensus sequence.
+        rep_idx = _pick_representative(fallback_idx=0, cluster_dictionary=cluster_dictionary)
+        self.assertNotEqual(rep_idx, 0)
+        self.assertEqual(cluster_dictionary[rep_idx]["ins_seq"], "MAJORITY")
+
+    def test_falls_back_to_degree_anchor_when_no_consensus_sequence(self):
+        """Mixed cluster (some members lack a sequence): no single medoid
+        exists, so the degree-based fallback index is used, matching the
+        pre-existing behaviour for symbolic/mixed clusters.
+        """
+        cluster_dictionary = {
+            0: {"posA": 100, "ins_seq": "SEQ"},
+            1: {"posA": 200, "ins_seq": None},  # symbolic member -> no consensus possible
+        }
+        rep_idx = _pick_representative(fallback_idx=1, cluster_dictionary=cluster_dictionary)
+        self.assertEqual(rep_idx, 1)
+
+    def test_cluster_variants_star_uses_medoid(self):
+        """End-to-end through cluster_variants: representative POS comes from
+        the medoid row, not the arbitrary highest-degree row.
+        """
+        variant_dictionary = {
+            0: {"posA": 10878052, "posB": 10878052, "sample_id": "s0", "ins_seq": "AAAA", "ins_len": 4},
+            1: {"posA": 10878053, "posB": 10878053, "sample_id": "s1", "ins_seq": "CCCC", "ins_len": 4},
+            2: {"posA": 10878054, "posB": 10878054, "sample_id": "s2", "ins_seq": "CCCC", "ins_len": 4},
+        }
+        similarity_matrix = {
+            0: np.array([0, 1, 2]),  # highest degree, but its own seq (AAAA) is the minority
+            1: np.array([1]),
+            2: np.array([2]),
+        }
+        clusters = cluster_variants(variant_dictionary, similarity_matrix)
+        self.assertEqual(len(clusters), 1)
+        rep = clusters[0][0]
+        self.assertEqual(rep["ins_seq"], "CCCC")
+        self.assertIn(rep["posA"], (10878053, 10878054))
+
+    def test_cluster_variants_union_find_uses_medoid(self):
+        """Same medoid preference through cluster_variants_union_find."""
+        variant_dictionary = {
+            0: {"posA": 10878052, "posB": 10878052, "sample_id": "s0", "ins_seq": "AAAA", "ins_len": 4},
+            1: {"posA": 10878053, "posB": 10878053, "sample_id": "s1", "ins_seq": "CCCC", "ins_len": 4},
+            2: {"posA": 10878054, "posB": 10878054, "sample_id": "s2", "ins_seq": "CCCC", "ins_len": 4},
+        }
+        similarity_matrix = {
+            0: np.array([0, 1, 2]),
+            1: np.array([0, 1, 2]),
+            2: np.array([0, 1, 2]),
+        }
+        clusters = cluster_variants_union_find(variant_dictionary, similarity_matrix)
+        self.assertEqual(len(clusters), 1)
+        rep = clusters[0][0]
+        self.assertEqual(rep["ins_seq"], "CCCC")
+        self.assertIn(rep["posA"], (10878053, 10878054))
 
 
 class TestClusterMethodIntegration:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -344,7 +344,7 @@ class TestPickRepresentative(unittest.TestCase):
     ins_seq matches the cluster's consensus) over the degree-based anchor,
     so POS/SVLEN/ALT come from one self-consistent row instead of stitching
     together an unrelated high-degree row's position with a different row's
-    sequence -- the exact failure traced in issue #93/#95.
+    sequence -- the exact failure traced in issue #93, fixed per issue #96.
     """
 
     def test_prefers_medoid_over_high_degree_row_with_different_sequence(self):


### PR DESCRIPTION
## Summary
- Fixes #96 (representative selection can diverge from its own cluster's consensus, root-caused during investigation of #93)
- `cluster_variants` and `cluster_variants_union_find` now pick the exported representative row as the cluster's **medoid** (an actual member whose own `ins_seq` already equals `_pick_ins_seq(cluster)`), falling back to the old highest-degree row for mixed/symbolic clusters where no single consensus sequence exists
- Degree still decides claiming order/membership — unchanged. Only which row's `POS`/`SVLEN`/`ALT` gets displayed changes
- `docs/algorithms.md` and `docs/architecture.md` updated to describe medoid-based selection instead of stating the highest-degree row as the representative outright

## Why
Two genuinely different clusters (each anchored by a different minority-length allele, e.g. 52bp vs 68bp) could both converge on displaying the *same* majority-vote consensus sequence, making them look like duplicate/identical output lines with no visibility into why they weren't merged — traced in detail in #93. The representative row driving the clustering decision was never actually the one displayed.

## Test plan
- [x] 4 new tests in `tests/test_export.py::TestPickRepresentative` covering medoid preference (both `star` and `union_find`) and the mixed-cluster fallback
- [x] Full suite: 374/374 passing, mypy clean
- [x] No changes to `--coarse` path (uses centroid, not a representative row — out of scope)