### PR TITLE
Treat N-heavy insertion sequences as absent for similarity comparison

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -52,7 +52,10 @@ cascade of gates — cheapest first to minimise work:
 2. **SVLEN ratio gate** (vectorised): requires `min(svlen)/max(svlen) ≥ --ins_svlen_ratio`
    for insertions with known length.
 3. **Sequence similarity gate** (Levenshtein, per-pair): requires similarity ≥
-   `--ins_seq_similarity` for insertions with known sequence.
+   `--ins_seq_similarity` for insertions with known sequence. Sequences over
+   10% ambiguous 'N' bases (`ins_similarity.has_excess_n`) are treated as
+   absent — N content makes Levenshtein similarity meaningless, so such
+   insertions fall back to position+SVLEN matching instead.
 
 The similarity graph (which variants can be merged with which) is then
 collapsed by one of two algorithms:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,9 @@ See [algorithms.md](algorithms.md) for full parameter and algorithm reference.
 | Sequence similarity | INS | per-pair rapidfuzz Levenshtein (`--ins_seq_similarity`) |
 
 The sequence gate is irreducibly serial; the earlier gates eliminate the vast
-majority of candidates before it runs.
+majority of candidates before it runs. Sequences over 10% 'N' bases
+(`ins_similarity.has_excess_n`) are treated as absent across build/query/merge/
+export alike, deferring to position+SVLEN matching same as a symbolic ALT.
 
 **Clustering** (`--cluster_method`): operates on the similarity graph output
 of `expand_chain`. `star` (default): greedy, no transitivity; a variant that

--- a/svdb/export_module.py
+++ b/svdb/export_module.py
@@ -62,6 +62,11 @@ def fetch_all_variants(variant, chrA, chrB, db, max_ins_seq_len=None):
     max_ins_seq_len: if set, sequences longer than this are treated as None
     during comparison (position+SVLEN only); the full sequence is still written
     to the ALT field of the output VCF.
+
+    Sequences too dominated by ambiguous 'N' bases (ins_similarity.has_excess_n)
+    are likewise treated as None -- N content makes sequence similarity
+    meaningless, so such insertions fall back to position+SVLEN matching same
+    as a symbolic ALT.
     """
     has_ins = db.has_ins_table()
     if has_ins:
@@ -84,6 +89,8 @@ def fetch_all_variants(variant, chrA, chrB, db, max_ins_seq_len=None):
         idx = int(hit[3])
         seq = decompress_ins_seq(hit[4]) if has_ins else None
         if seq and max_ins_seq_len is not None and len(seq) > max_ins_seq_len:
+            seq = None
+        if seq and ins_similarity.has_excess_n(seq):
             seq = None
         variant_dict[idx] = {
             "posA": int(hit[0]),

--- a/svdb/ins_similarity.py
+++ b/svdb/ins_similarity.py
@@ -15,7 +15,12 @@ Public API used by merge, query, and export pipelines:
 
   cap_seq(seq, max_len) -> str
       Cap insertion sequence to max_len before comparison; returns "" if over
-      the cap, which causes sequence_gate to defer to position+SVLEN.
+      the cap or too N-heavy (see has_excess_n), which causes sequence_gate
+      to defer to position+SVLEN.
+
+  has_excess_n(seq, max_n_fraction) -> bool
+      True if seq is too dominated by ambiguous 'N' bases for Levenshtein
+      similarity to be meaningful.
 
   parse_svlen(info_str) -> Optional[int]
       Extract |SVLEN| from a VCF INFO string.
@@ -34,6 +39,12 @@ from typing import Optional, Union
 from rapidfuzz.distance import Levenshtein
 
 logger = logging.getLogger(__name__)
+
+# Sequences at or above this fraction of 'N' bases are treated as absent for
+# similarity purposes — same defer-to-position+SVLEN behaviour as a symbolic
+# ALT. Not exposed as a CLI flag; matches the internal-constant style of
+# query_module._INS_SEQ_HARD_CAP.
+_MAX_N_FRACTION = 0.1
 
 # Effective defaults when no profile and no explicit flag is set.
 _INS_DEFAULTS: dict = {
@@ -120,15 +131,34 @@ def sequence_gate(seq_a: str, seq_b: str, threshold: float) -> bool:
     return levenshtein_similarity(seq_a, seq_b, score_cutoff=threshold) >= threshold
 
 
+def has_excess_n(seq: Optional[str], max_n_fraction: float = _MAX_N_FRACTION) -> bool:
+    """Return True if seq is too dominated by ambiguous 'N' bases for
+    Levenshtein similarity to be meaningful.
+
+    N marks masked/unresolved bases, not real sequence content — comparing
+    two N-heavy sequences can score deceptively high (both mostly the same
+    placeholder character) or deceptively low, either way telling you
+    nothing about the real insertion. Case-insensitive.
+    """
+    if not seq:
+        return False
+    return (seq.upper().count("N") / len(seq)) > max_n_fraction
+
+
 def cap_seq(seq: Optional[str], max_len: Optional[int]) -> str:
-    """Return seq unchanged if within max_len; return "" if it exceeds the cap.
+    """Return seq unchanged if within max_len and not too N-heavy; return ""
+    otherwise.
 
     An empty return causes sequence_gate to skip similarity and defer to
     position+SVLEN matching — consistent with symbolic ALT behaviour.
     """
-    if seq and max_len is not None and len(seq) > max_len:
+    if not seq:
         return ""
-    return seq or ""
+    if max_len is not None and len(seq) > max_len:
+        return ""
+    if has_excess_n(seq):
+        return ""
+    return seq
 
 
 def parse_svlen(info_str: str) -> Optional[int]:

--- a/tests/test_ins_similarity.py
+++ b/tests/test_ins_similarity.py
@@ -16,6 +16,7 @@ from svdb.ins_similarity import (
     cap_seq,
     decompress_ins_seq,
     extract_ins_sequence,
+    has_excess_n,
     levenshtein_similarity,
     parse_svlen,
     sequence_gate,
@@ -186,6 +187,38 @@ class TestSequenceGate:
         assert sequence_gate(seq_a, seq_b, threshold=0.75) is True
 
 
+class TestHasExcessN:
+
+    def test_no_n_returns_false(self):
+        assert has_excess_n("ATCGATCGATCG") is False
+
+    def test_none_input_returns_false(self):
+        assert has_excess_n(None) is False
+
+    def test_empty_string_returns_false(self):
+        assert has_excess_n("") is False
+
+    def test_above_default_threshold_returns_true(self):
+        # 2/10 N = 0.2 > 0.1 default
+        assert has_excess_n("NNAAAAAAAA") is True
+
+    def test_exactly_at_default_threshold_returns_false(self):
+        # 1/10 N = 0.1, not > 0.1 -- boundary is not flagged
+        assert has_excess_n("NAAAAAAAAA") is False
+
+    def test_all_n_returns_true(self):
+        assert has_excess_n("NNNNNNNN") is True
+
+    def test_case_insensitive(self):
+        assert has_excess_n("nnnnaaaa") is True
+        assert has_excess_n("NnNnAAAA") is True
+
+    def test_custom_threshold(self):
+        seq = "NAAAAAAAAA"  # 1/10 = 0.1
+        assert has_excess_n(seq, max_n_fraction=0.2) is False
+        assert has_excess_n(seq, max_n_fraction=0.05) is True
+
+
 class TestCapSeq:
 
     def test_none_input_returns_empty(self):
@@ -206,6 +239,19 @@ class TestCapSeq:
     def test_exactly_at_cap_is_not_capped(self):
         seq = "A" * 500
         assert cap_seq(seq, 500) == seq
+
+    def test_excess_n_returns_empty(self):
+        """N-heavy sequence is treated the same as over-cap: deferred to
+        position+SVLEN matching, same as a symbolic ALT -- issue #95."""
+        assert cap_seq("NNNNNNNNAA", None) == ""
+
+    def test_excess_n_then_sequence_gate_defers(self):
+        """End-to-end: an N-heavy sequence run through cap_seq (as merge and
+        query do) makes sequence_gate defer (return True) regardless of how
+        dissimilar the other side is."""
+        n_heavy = cap_seq("NNNNNNNNNN", None)
+        other = cap_seq("ATCGATCGAT", None)
+        assert sequence_gate(n_heavy, other, threshold=0.99) is True
 
 
 class TestDecompressInsSeq:

--- a/tests/test_sqlite_ins.py
+++ b/tests/test_sqlite_ins.py
@@ -441,6 +441,28 @@ class TestExportINS:
         # All four cluster together (position_only); most common seq is ACGTACGT
         assert any("NACGTACGT" in line for line in lines)
 
+    def test_export_n_heavy_sequence_treated_as_symbolic(self, tmp_path):
+        """N-heavy sequence is nulled out for comparison (issue #95): a clean
+        sequence and an N-heavy one at the same position/SVLEN merge on
+        position+SVLEN alone -- without the guard, the sequence gate would
+        reject them (a clean sequence vs all-N looks maximally dissimilar)
+        and they'd export as two separate lines instead of one mixed,
+        symbolic cluster.
+        """
+        vcf = tmp_path / "sample.vcf"
+        make_ins_vcf(vcf, [
+            ("1", 1000, "ins1", "A" * 16),
+            ("1", 1001, "ins2", "N" * 16),
+        ])
+        build(tmp_path / "svdb", vcf)
+        r = run("--export", "--db", str(tmp_path / "svdb.db"),
+                "--prefix", str(tmp_path / "out"))
+        assert r.returncode == 0
+        lines = data_lines((tmp_path / "out.vcf").read_text())
+        ins_lines = [ln for ln in lines if "SVTYPE=INS" in ln]
+        assert len(ins_lines) == 1
+        assert "<INS>" in ins_lines[0]
+
     def test_export_ins_svlen_ratio_separates_different_lengths(self, tmp_path):
         """Default ratio=0.90 keeps very different lengths in separate clusters."""
         vcf = tmp_path / "sample.vcf"


### PR DESCRIPTION
## Summary
- Fixes #95
- Adds `ins_similarity.has_excess_n(seq, max_n_fraction=0.1)`: True when a sequence is more than 10% ambiguous 'N' bases
- Wired into `cap_seq()` (covers `merge` and `query`, both already route sequence comparisons through it) and into `export_module.fetch_all_variants`'s inline capping (export doesn't call `cap_seq` directly, so needed the same check added explicitly to stay consistent)
- `_MAX_N_FRACTION` is a private module-level constant in `ins_similarity.py` (not a CLI flag), matching the existing style of `query_module._INS_SEQ_HARD_CAP` — centralized there since merge/query/export all need the same threshold rather than three independently-tunable copies

## Why
N marks masked/unresolved bases, not real sequence content. Comparing an N-heavy sequence against a real one via Levenshtein similarity is meaningless — it can score deceptively low (making genuinely-the-same insertion look dissimilar) since N vs any real base always counts as a mismatch. N-heavy sequences should defer to position+SVLEN matching, same as a symbolic `<INS>` allele already does.

## Test plan
- [x] `tests/test_ins_similarity.py::TestHasExcessN` — threshold boundary, case-insensitivity, custom threshold override
- [x] `tests/test_ins_similarity.py::TestCapSeq` — N-heavy sequence capped to `""`, end-to-end `sequence_gate` deferral
- [x] `tests/test_sqlite_ins.py::TestExportINS::test_export_n_heavy_sequence_treated_as_symbolic` — end-to-end: a clean sequence and an N-heavy one at the same position/SVLEN merge into one symbolic `<INS>` cluster instead of two separate lines
- [x] Full suite: 381/381 passing, mypy clean