### PR TITLE
CI: add tag-triggered release version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+# Tag-triggered. Runs as its own workflow (separate from CI in main.yml) since
+# it's release-specific rather than ongoing-test-specific, and grows into a
+# real build/publish pipeline later.
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+
+  version-check:
+
+    name: Verify tag matches setup.py version
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Validate tag looks like a version
+        run: |
+          TAG_CLEAN="${GITHUB_REF_NAME#v}"
+          if ! [[ "$TAG_CLEAN" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' does not look like a semantic version (expected e.g. 2.11.2 or v2.11.2) -- skipping version comparison"
+            exit 1
+          fi
+
+      - name: Compare git tag to setup.py version
+        run: |
+          pip install --quiet setuptools
+          TAG_CLEAN="${GITHUB_REF_NAME#v}"
+          PACKAGE_VERSION=$(python setup.py --version)
+          if [ "$PACKAGE_VERSION" != "$TAG_CLEAN" ]; then
+            echo "::error::Version mismatch: setup.py version ($PACKAGE_VERSION) does not match release tag ($TAG_CLEAN). Update setup.py's version= and push a matching tag."
+            exit 1
+          fi
+          echo "OK: setup.py version ($PACKAGE_VERSION) matches tag ($TAG_CLEAN)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
 name: Release
 
 # Tag-triggered. Runs as its own workflow (separate from CI in main.yml) since
-# it's release-specific rather than ongoing-test-specific, and grows into a
-# real build/publish pipeline later.
+# it's release-specific rather than ongoing-test-specific.
 on:
   push:
     tags:
       - "*"
+
+# Least-privilege default; the publish job below opts back into id-token
+# write for PyPI trusted publishing.
+permissions:
+  contents: read
 
 jobs:
 
@@ -41,3 +45,89 @@ jobs:
             exit 1
           fi
           echo "OK: setup.py version ($PACKAGE_VERSION) matches tag ($TAG_CLEAN)"
+
+  build:
+
+    name: Build sdist and wheel
+    needs: version-check
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      # No Cython in [build-system] requires (pyproject.toml), so this
+      # isolated build never sees Cython -- setup.py's own try/except
+      # degrades to ext_modules=[], producing one portable py3-none-any
+      # wheel. No manylinux/cibuildwheel/multi-OS matrix needed.
+      - name: Build sdist and wheel
+        run: |
+          pip install --quiet build
+          python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test-built-artifacts:
+
+    name: Test the built wheel and sdist (not the source checkout)
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      # Tests run from a directory containing ONLY tests/, not the repo's
+      # own svdb/ source -- otherwise pytest can silently import the local
+      # source tree instead of the installed artifact, defeating the point
+      # of this job. Verified locally: `import svdb; svdb.__file__` resolves
+      # to site-packages, not the checkout, with this layout.
+      - name: Test installed wheel
+        run: |
+          python -m venv /tmp/venv_wheel
+          /tmp/venv_wheel/bin/pip install --quiet dist/*.whl pytest scipy
+          mkdir -p /tmp/wheel_test && cp -r tests /tmp/wheel_test/
+          cd /tmp/wheel_test && /tmp/venv_wheel/bin/pytest -v
+
+      - name: Test installed sdist
+        run: |
+          python -m venv /tmp/venv_sdist
+          /tmp/venv_sdist/bin/pip install --quiet dist/*.tar.gz pytest scipy
+          mkdir -p /tmp/sdist_test && cp -r tests /tmp/sdist_test/
+          cd /tmp/sdist_test && /tmp/venv_sdist/bin/pytest -v
+
+  publish:
+
+    name: Publish to PyPI
+    needs: [version-check, test-built-artifacts]
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    permissions:
+      id-token: write
+
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml`, separate from the existing CI in `main.yml` (release-specific vs. ongoing-test-specific), triggered on any tag push
- `version-check`: validates the tag looks like a semantic version, then compares it against `setup.py`'s `version=` — fails on mismatch
- `build`: `python -m build` → sdist + wheel
- `test-built-artifacts`: installs the built wheel and sdist into fresh venvs and runs the real test suite against each — isolated so pytest can't accidentally import the local source tree instead of the installed artifact
- `publish`: `pypa/gh-action-pypi-publish` via OIDC trusted publishing, gated on both `version-check` and `test-built-artifacts` passing
- No `pyproject.toml` `[project]` table exists in this repo, so `setup.py` stays the single source of truth — no packaging restructure needed
- This is a from-scratch release pipeline; there's no existing automated PyPI publish today

## @J35P312 — setup needed before `publish` can actually run

I don't have the access to do any of this myself (checked: this account has `push` but not `admin`/`maintain` on the repo, and PyPI project administration is separate from GitHub entirely). The workflow is ready to go the moment these are done:

1. **On pypi.org**, as the `svdb` project's owner/maintainer: go to the project's *Settings → Publishing* and add a new **trusted publisher**, pointing at:
   - Repository owner: `J35P312`
   - Repository name: `SVDB`
   - Workflow filename: `release.yml`
   - Environment name: `pypi`
   
   This is the secretless OIDC approach (no API token to generate, store, or rotate) — same mechanism as the `id_tokens: PYPI_ID_TOKEN` block in the GitLab template this was based on.

2. **On GitHub**, the `pypi` environment referenced by the `publish` job's `environment:` key will auto-create itself (unprotected) on first run if it doesn't already exist. Optional but recommended: create it explicitly under repo *Settings → Environments* first, and add protection rules (e.g. required reviewers before a publish runs, restrict to tag pushes only) — this needs repo admin access.

3. If trusted publishing isn't wanted for some reason, the fallback is a classic PyPI API token stored as a repo secret (`Settings → Secrets and variables → Actions`) — also needs a PyPI project admin to generate the token, and repo admin to add the secret. I'd recommend trusted publishing over this if possible.

Nothing else in this PR depends on the above — `version-check`, `build`, and `test-built-artifacts` all work today and will run (and can be reviewed/merged) regardless. Only `publish` will fail until step 1 is done.

## Notes
- A GitHub Actions job triggered by a tag push can't prevent the tag from existing — it can only fail the check on that tag after the fact, which needs a human to notice and act on (delete + re-tag, or push a fixed tag)
- Tag matching accepts an optional `v` prefix (`2.11.2` or `v2.11.2`) — this repo's existing tags have no prefix, kept for forward compatibility
- No manylinux/cibuildwheel/multi-OS build matrix needed: `pyproject.toml`'s `[build-system] requires` doesn't list Cython, so the isolated build backend never sees it — `setup.py`'s own `try/except ImportError` degrades to `ext_modules=[]`, producing one portable `py3-none-any` wheel. Verified locally. (Also true of today's `pip install .` in `main.yml` — the Cython-compiled path has never actually been exercised in CI.)

## Test plan
- [x] YAML syntax validated
- [x] Bash comparison logic simulated locally for 4 version-check cases: exact match, `v`-prefixed match, stale/mismatched version, non-version-shaped tag — all behaved correctly
- [x] `python -m build` run locally against this repo as-is — produces `svdb-2.11.1-py3-none-any.whl` + sdist cleanly, no changes needed
- [x] Installed the built wheel into a fresh venv and ran the full test suite from a directory containing only `tests/` (not the checkout's `svdb/`) — confirmed `svdb.__file__` resolves to `site-packages`, not local source; 339 tests passed